### PR TITLE
fix json error when poi-icons-svg file does not exist

### DIFF
--- a/map/src/infoblock/components/favorite/AddFavoriteDialog.jsx
+++ b/map/src/infoblock/components/favorite/AddFavoriteDialog.jsx
@@ -47,12 +47,14 @@ export default function AddFavoriteDialog({dialogOpen, setDialogOpen}) {
     }, [dialogOpen]);
 
     async function getIconCategories() {
-        let resp = await fetch(FavoritesManager.FAVORITE_GROUP_FOLDER)
-        const res = await resp.json();
-        if (res) {
-            setCurrentIconCategories('special');
-            setFavoriteIconCategories(res);
-        }
+        let resp = await fetch(FavoritesManager.FAVORITE_GROUP_FOLDER);
+        try {
+            const res = await resp.json();
+            if (res) {
+                setCurrentIconCategories('special');
+                setFavoriteIconCategories(res);
+            }
+        } catch { /* console.log("json error (please download OsmAnd-resources)", FavoritesManager.FAVORITE_GROUP_FOLDER); */ };
     }
 
     async function save() {


### PR DESCRIPTION
The JSON error happens when no OsmAnd-resources installed.
Call of json.parse on non-existing "poi-icons-svg" file causes error.
Added "try / catch" to fix this error.