### PR TITLE
rzr bugs 27jul

### DIFF
--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -18,6 +18,7 @@ const LOCAL_COMPRESSED_TRACK_KEY = 'localTrack_';
 const DATA_SIZE_KEY = 'dataSize';
 const TRACK_VISIBLE_FLAG = 'visible';
 const HOURS_24_MS = 86400000;
+const FIT_BOUNDS_OPTIONS = { maxZoom: 17 }; // don't fitBounds closer
 
 async function loadTracks(setLoading) {
     let localTracks = [];
@@ -775,6 +776,7 @@ const TracksManager = {
     CHANGE_PROFILE_AFTER: CHANGE_PROFILE_AFTER,
     CHANGE_PROFILE_ALL: CHANGE_PROFILE_ALL,
     TRACK_VISIBLE_FLAG: TRACK_VISIBLE_FLAG,
+    FIT_BOUNDS_OPTIONS: FIT_BOUNDS_OPTIONS,
 };
 
 export default TracksManager;

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -68,7 +68,6 @@ function openVisibleTracks(localTracks) {
                 if (f.name === local.name) {
                     if (Date.now() - local.addTime < HOURS_24_MS) {
                         f.selected = true;
-                        f.index = _.indexOf(localTracks, f);
                     } else {
                         f.selected = false;
                     }
@@ -83,11 +82,8 @@ function saveLocalTrack(tracks, ctx) {
     let currentTrackIndex = tracks.findIndex((t) => t.name === ctx.selectedGpxFile.name);
 
     if (currentTrackIndex === -1) {
-        ctx.selectedGpxFile.index = tracks.length; // mutate state (ctx)
         tracks.push(ctx.selectedGpxFile); // mutate state (via parameter)
-
         // instant call setState if you don't sure about parent
-        ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
         ctx.setLocalTracks([...ctx.localTracks]);
 
         currentTrackIndex = tracks.findIndex((t) => t.name === ctx.selectedGpxFile.name);
@@ -293,7 +289,6 @@ function openNewLocalTrack(ctx) {
     ctx.setCurrentObjectType(type);
     let selectedTrack = ctx.localTracks[ctx.localTracks.length - 1];
     selectedTrack.selected = true;
-    selectedTrack.index = ctx.localTracks.length - 1;
     ctx.setCreateTrack({
         enable: true,
         edit: true,

--- a/map/src/drawer/components/VisibleGroup.jsx
+++ b/map/src/drawer/components/VisibleGroup.jsx
@@ -150,18 +150,11 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     {visibleTracks.local.length > 0 &&
                         visibleTracks.local.map((track, index) => {
-                            return (
-                                <LocalTrackItem
-                                    className={classes.item}
-                                    key={track + index}
-                                    track={track}
-                                    index={track.index}
-                                />
-                            );
+                            return <LocalTrackItem className={classes.item} key={'vis-local-' + index} track={track} />;
                         })}
                     {visibleTracks.cloud.length > 0 &&
                         visibleTracks.cloud.map((track, index) => {
-                            return <CloudTrackItem className={classes.item} key={track + index} file={track} />;
+                            return <CloudTrackItem className={classes.item} key={'vis-cloud-' + index} file={track} />;
                         })}
                 </div>
             </Collapse>

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -13,7 +13,7 @@ export default function Actions({ files, setSortFiles }) {
                 sx={{ ml: 4 }}
                 onClick={(e) => {
                     e.stopPropagation();
-                    let lf = files.sort((f, s) => {
+                    const sortedCopy = [...files].sort((f, s) => {
                         let ftime = getGpxTime(f);
                         let stime = getGpxTime(s);
                         if (ftime === stime) {
@@ -26,7 +26,7 @@ export default function Actions({ files, setSortFiles }) {
                         }
                     });
                     setTimeUp(!timeUp);
-                    setSortFiles([...lf]);
+                    setSortFiles(sortedCopy);
                 }}
             >
                 <Sort fontSize="small" />
@@ -34,7 +34,7 @@ export default function Actions({ files, setSortFiles }) {
             <IconButton
                 onClick={(e) => {
                     e.stopPropagation();
-                    let lf = files.sort((f, s) => {
+                    const sortedCopy = [...files].sort((f, s) => {
                         if (alphaUp) {
                             return f.name > s.name ? 1 : -1;
                         } else {
@@ -42,7 +42,7 @@ export default function Actions({ files, setSortFiles }) {
                         }
                     });
                     setAlphaUp(!alphaUp);
-                    setSortFiles([...lf]);
+                    setSortFiles(sortedCopy);
                 }}
             >
                 <SortByAlpha fontSize="small" />

--- a/map/src/drawer/components/tracks/CloudTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackGroup.jsx
@@ -107,7 +107,7 @@ export default function CloudTrackGroup({ index, group }) {
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     <Actions files={group.files} setSortFiles={setSortFiles} />
                     {(sortFiles.length > 0 ? sortFiles : group.files).map((file, index) => {
-                        return <CloudTrackItem key={file + index} file={file} />;
+                        return <CloudTrackItem key={'cloudtrack-' + index} file={file} />;
                     })}
                 </div>
             </Collapse>

--- a/map/src/drawer/components/tracks/LocalTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackGroup.jsx
@@ -121,12 +121,12 @@ export default function LocalTrackGroup() {
                     <Actions files={ctx.localTracks} setSortFiles={setSortFiles} />
                     {!_.isEmpty(sortFiles) &&
                         sortFiles.map((track, index) => {
-                            return <LocalTrackItem key={'track' + index} track={track} index={index} />;
+                            return <LocalTrackItem key={'sortedtrack-' + index} track={track} />;
                         })}
                     {_.isEmpty(sortFiles) &&
                         ctx.localTracks.length > 0 &&
                         ctx.localTracks.map((track, index) => {
-                            return <LocalTrackItem key={'track' + index} track={track} index={index} />;
+                            return <LocalTrackItem key={'localtrack-' + index} track={track} />;
                         })}
                 </div>
                 <MenuItem disableRipple={true}>

--- a/map/src/drawer/components/tracks/LocalTrackItem.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackItem.jsx
@@ -48,7 +48,7 @@ export default function LocalTrackItem({ track }) {
 
     function updateLocalTrack() {
         ref.selected = true;
-        // ref.zoom = true; // selected is enough for init-zoom
+        ref.zoom = true;
         ref.analysis = TracksManager.prepareAnalysis(ref.analysis);
         ctx.setLocalTracks([...ctx.localTracks]);
         ctx.setSelectedGpxFile({ ...track });

--- a/map/src/infoblock/components/InformationBlock.jsx
+++ b/map/src/infoblock/components/InformationBlock.jsx
@@ -63,7 +63,7 @@ export default function InformationBlock({
     }, [mobile, showContextMenu, hideContextMenu]);
 
     useEffect(() => {
-        if (ctx.currentObjectType !== ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK && ctx.createTrack) {
+        if (ctx.currentObjectType && ctx.currentObjectType !== ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK && ctx.createTrack) {
             stopCreatedTrack(true);
         }
     }, [ctx.currentObjectType]);

--- a/map/src/infoblock/components/favorite/AddFavoriteDialog.jsx
+++ b/map/src/infoblock/components/favorite/AddFavoriteDialog.jsx
@@ -119,10 +119,9 @@ export default function AddFavoriteDialog({ dialogOpen, setDialogOpen }) {
             ctx.localTracks[ind].pointsGroups = ctx.selectedGpxFile.pointsGroups;
         } else {
             TracksManager.prepareTrack(ctx.selectedGpxFile);
-            ctx.selectedGpxFile.index = ctx.localTracks.length;
             ctx.localTracks.push(ctx.selectedGpxFile);
         }
-        TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setSelectedGpxFile + setLocalTracks
+        TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setLocalTracks
         ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
         ctx.setLocalTracks([...ctx.localTracks]);
     }

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -187,7 +187,7 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
 
             ctx.selectedGpxFile.name = newName;
 
-            TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setSelectedGpxFile + setLocalTracks
+            TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setLocalTracks
             ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
             ctx.setLocalTracks([...ctx.localTracks]);
 

--- a/map/src/infoblock/components/track/dialogs/DescTrackDialog.jsx
+++ b/map/src/infoblock/components/track/dialogs/DescTrackDialog.jsx
@@ -81,7 +81,7 @@ export default function DescTrackDialog({ dialogOpen, setDialogOpen }) {
     }
 
     function saveState() {
-        TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setSelectedGpxFile + setLocalTracks
+        TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setLocalTracks
         ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
     }
 

--- a/map/src/map/layers/FavoriteLayer.js
+++ b/map/src/map/layers/FavoriteLayer.js
@@ -5,6 +5,7 @@ import { useMap } from 'react-leaflet';
 import TrackLayerProvider from '../TrackLayerProvider';
 import AddFavoriteDialog from '../../infoblock/components/favorite/AddFavoriteDialog';
 import FavoritesManager from '../../context/FavoritesManager';
+import TracksManager from '../../context/TracksManager';
 import _ from 'lodash';
 
 const FavoriteLayer = () => {
@@ -39,7 +40,7 @@ const FavoriteLayer = () => {
                         file.name === ctx.selectedGpxFile.file?.name &&
                         !ctx.selectedGpxFile.editFavorite
                     ) {
-                        map.fitBounds(file.markers.getBounds());
+                        map.fitBounds(file.markers.getBounds(), TracksManager.FIT_BOUNDS_OPTIONS);
                     }
                 }
             } else if (!file.url && file.markers) {

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -140,6 +140,7 @@ export default function LocalClientTrackLayer() {
             saveResult(ctx.createTrack.closePrev.file, true);
             delete ctx.createTrack.closePrev;
             delete ctx.createTrack.layers;
+            ctx.setCreateTrack({ ...ctx.createTrack });
         }
         if (ctx.createTrack?.enable && !ctx.createTrack?.layers) {
             if (ctx.createTrack.edit) {
@@ -754,7 +755,7 @@ export default function LocalClientTrackLayer() {
 
     function initNewTrack() {
         ctxTrack = {};
-        // ctxTrack.selected = true; // FIXME
+        // ctxTrack.selected = true; // wrong way
         ctxTrack.name = TracksManager.createName(ctx);
         ctxTrack.tracks = TracksManager.createGpxTracks();
         ctxTrack.pointsGroups = {};

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -106,7 +106,7 @@ export default function LocalClientTrackLayer() {
         Object.values(ctx.localTracks).forEach((track) => {
             let currLayer = localLayers[track.name];
             if (track.selected && !currLayer) {
-                const needFitBounds = track.points?.length > 1 || track.wpts?.length > 0; // don't zoom on empty track
+                const needFitBounds = track.points?.length > 1 || track.wpts?.length > 0 || track.tracks?.length > 0;
                 addTrackToMap(track, needFitBounds, true);
             } else if (currLayer) {
                 currLayer.active = track.selected;

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -174,7 +174,6 @@ export default function LocalClientTrackLayer() {
         let ind = ctx.localTracks.findIndex((t) => t.name === file.name);
         if (ind !== -1) {
             ctx.localTracks[ind] = file;
-            ctx.localTracks[ind].index = ind;
             if (ctx.createTrack.clear) {
                 ctx.localTracks[ind].selected = false;
             } else {
@@ -184,7 +183,7 @@ export default function LocalClientTrackLayer() {
                     ctx.localTracks[ind].selected = true;
                 }
             }
-            TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setSelectedGpxFile + setLocalTracks
+            TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setLocalTracks
             ctx.setLocalTracks([...ctx.localTracks]);
 
             if (ctx.createTrack.clear) {
@@ -225,7 +224,7 @@ export default function LocalClientTrackLayer() {
     function saveLocal() {
         if (ctx.localTracks.length > 0) {
             // localTracks exist: do update/append
-            TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setSelectedGpxFile + setLocalTracks
+            TracksManager.saveTracks(ctx.localTracks, ctx); // saveTracks + setLocalTracks
         } else {
             // localTracks empty: add gpx as 1st track (points and/or wpts are included)
             createLocalTrack(ctxTrack, ctxTrack.points, ctxTrack.wpts);
@@ -515,8 +514,6 @@ export default function LocalClientTrackLayer() {
 
         file.tracks = [{ points, wpts }];
         file.layers = TrackLayerProvider.createLayersByTrackData(file);
-        file.index = ctx.localTracks.length;
-        // file.selected = true; // FIXME
 
         ctx.localTracks.push(file);
         ctx.setLocalTracks([...ctx.localTracks]);

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -107,7 +107,8 @@ export default function LocalClientTrackLayer() {
         Object.values(ctx.localTracks).forEach((track) => {
             let currLayer = localLayers[track.name];
             if (track.selected && !currLayer) {
-                addTrackToMap(track, true, true);
+                const needFitBounds = track.points?.length > 1 || track.wpts?.length > 0; // don't zoom on empty track
+                addTrackToMap(track, needFitBounds, true);
             } else if (currLayer) {
                 currLayer.active = track.selected;
                 if (track.updated) {
@@ -246,7 +247,7 @@ export default function LocalClientTrackLayer() {
         if (layer) {
             if (fitBounds) {
                 if (!_.isEmpty(layer.getBounds())) {
-                    map.fitBounds(layer.getBounds());
+                    map.fitBounds(layer.getBounds(), TracksManager.FIT_BOUNDS_OPTIONS);
                 }
             }
             layer.on('click', () => {
@@ -287,7 +288,7 @@ export default function LocalClientTrackLayer() {
     function showSelectedTrackOnMap() {
         let currLayer = localLayers[ctxTrack.name];
         if (currLayer) {
-            map.fitBounds(currLayer.layer.getBounds());
+            map.fitBounds(currLayer.layer.getBounds(), TracksManager.FIT_BOUNDS_OPTIONS);
         }
     }
 

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -70,7 +70,6 @@ export default function LocalClientTrackLayer() {
                     saveLocal();
                 }
                 checkZoom();
-                // checkClickOnMapEvent();
                 checkUpdateLayers();
             }
         }
@@ -151,7 +150,6 @@ export default function LocalClientTrackLayer() {
                 ctx.setCurrentObjectType(type);
                 initNewTrack();
             }
-            // addClickOnMap();
         } else if (ctx.createTrack?.enable === false) {
             if (ctx.createTrack.clear) {
                 clearCreateLayers(ctxTrack.layers);
@@ -166,7 +164,6 @@ export default function LocalClientTrackLayer() {
             }
             saveResult(savedFile, false);
             ctx.setCreateTrack(null);
-            // deleteClickOnMap();
         }
     }, [ctx.createTrack]);
 
@@ -212,14 +209,6 @@ export default function LocalClientTrackLayer() {
             ctx.setSelectedGpxFile({});
         }
     }
-
-    // function checkClickOnMapEvent() {
-    //     if (ctx.selectedGpxFile.addPoint && !ctx.selectedGpxFile.addWpt) {
-    //         //getNewRoute();
-    //     } else {
-    //         checkDragPoint();
-    //     }
-    // }
 
     function saveLocal() {
         if (ctx.localTracks.length > 0) {
@@ -303,16 +292,6 @@ export default function LocalClientTrackLayer() {
             setSelectedPointMarker({ marker: marker, trackName: ctxTrack.name });
         }
     }
-
-    // function checkDragPoint() {
-    //     if (ctx.selectedGpxFile?.dragPoint) {
-    //         deleteClickOnMap();
-    //     } else {
-    //         if (ctx.createTrack?.enable) {
-    //             addClickOnMap();
-    //         }
-    //     }
-    // }
 
     function checkUpdateLayers() {
         if (ctxTrack?.updateLayers) {
@@ -744,9 +723,6 @@ export default function LocalClientTrackLayer() {
             geoProfile: geoProfile,
             geometry: [],
         };
-        // if (newPoint.profile !== TracksManager.PROFILE_LINE) {
-        //     newPoint.geometry = []; // geometry is already set to [] just few lines before
-        // }
         return newPoint;
     }
 

--- a/map/src/map/layers/TrackLayer.js
+++ b/map/src/map/layers/TrackLayer.js
@@ -14,7 +14,7 @@ async function addTrackToMap(ctx, file, map) {
         ctx.setUpdateContextMenu(true);
     });
     file.gpx = layer;
-    map.fitBounds(layer.getBounds());
+    map.fitBounds(layer.getBounds(), TracksManager.FIT_BOUNDS_OPTIONS);
     layer.addTo(map);
     ctx.setGpxFiles(ctx.gpxFiles);
     ctx.setSelectedGpxFile(Object.assign({}, file));


### PR DESCRIPTION
**Fix bug with lost state after closePrev processed**

- [x] test: when you have several Local tracks, test click between them in Local tracks list, every click should start Edit track (compare behavior with the production)

**Remake LocalTrackItem, drop track.index, fix keys**

- [x] test: check that created track moves to Visible once after created+closed

- [x] test: sorted A-Z Local tracks should work (click/edit should choose right track)

- [x] test: deleted Local tracks should not cause crashes when using Visible tracks list

**Improve fitBounds for empty track, add maxZoom: 17**

- [x] test: create empty track should not do zoom-to-fit

- [x] test: track with 1 point should not do zoom-to-fit

- [x] test: very small track (2-3 segments, 10 meters each) should not zoom-to-fit closer than 17

- [x] test fitBounds (should works) on a few external gpx-tracks