### PR TITLE
Add track-view colors, hide track-view points, add track actions, add cloud-track icon, disable undo/redo when busy, fix state bugs #2142

### DIFF
--- a/map/package.json
+++ b/map/package.json
@@ -54,6 +54,7 @@
     "scripts": {
         "start": "react-scripts start",
         "start:mobile": "HOST=0.0.0.0 react-scripts start",
+        "start:fallback": "USE_MAIN_API=yes react-scripts start",
         "build": "react-scripts build",
         "build:staging": "env-cmd -f .env.staging react-scripts build",
         "test": "react-scripts test",

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -262,7 +262,7 @@ function handleEditCloudTrack(ctx) {
         ctx,
         callback: proceed,
         skip: localTrackNotFound,
-        text: name + ' - local track found. Overwrite?',
+        text: name + ' - Local track found. Overwrite?',
     });
 }
 
@@ -479,6 +479,7 @@ async function getGpxTrack(file) {
     }
 
     return await apiPost(`${process.env.REACT_APP_GPX_API}/gpx/save-track-data`, trackData, {
+        apiCache: true,
         headers: {
             'Content-Type': 'application/json',
         },

--- a/map/src/infoblock/components/InformationBlock.jsx
+++ b/map/src/infoblock/components/InformationBlock.jsx
@@ -48,6 +48,7 @@ export default function InformationBlock({
 
     useEffect(() => {
         if (!showInfoBlock) {
+            // stop-editor (close button)
             stopCreatedTrack(false);
             ctx.mutateShowPoints({ points: true, wpts: true });
             ctx.setTrackRange(null);

--- a/map/src/infoblock/components/PanelButtons.jsx
+++ b/map/src/infoblock/components/PanelButtons.jsx
@@ -1,5 +1,5 @@
 import { ButtonGroup, IconButton, Paper, Tooltip, CircularProgress } from '@mui/material';
-import { Close, Delete, Cloud, CloudUpload, Redo, Undo, Create, MenuOpen } from '@mui/icons-material';
+import { Close, Delete, Cloud, CloudUpload, Redo, Undo, Create, MenuOpen, Download } from '@mui/icons-material';
 import React, { useContext, useEffect, useState } from 'react';
 import AppContext from '../../context/AppContext';
 import SaveTrackDialog from './track/dialogs/SaveTrackDialog';
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import TracksManager, { isEmptyTrack } from '../../context/TracksManager';
 import useUndoRedo from '../useUndoRedo';
 import { confirm } from '../../dialogs/GlobalConfirmationDialog';
+import { downloadGpx } from '../../infoblock/components/track/GeneralInfo';
 
 const PanelButtons = ({
     orientation,
@@ -131,7 +132,7 @@ const PanelButtons = ({
                                         onClick={() =>
                                             confirm({
                                                 ctx,
-                                                text: 'This is Cloud track. Open editor?',
+                                                text: 'This is Cloud track. Open Local editor?',
                                                 callback: () => TracksManager.handleEditCloudTrack(ctx),
                                             })
                                         }
@@ -188,19 +189,6 @@ const PanelButtons = ({
                                 </span>
                             </Tooltip>
                         )}
-                        {ctx.currentObjectType !== ctx.OBJECT_TYPE_WEATHER &&
-                            ctx.currentObjectType !== ctx.OBJECT_TYPE_POI && (
-                                <Tooltip title="Delete" arrow placement="right">
-                                    <IconButton
-                                        sx={{ mb: '1px' }}
-                                        variant="contained"
-                                        type="button"
-                                        onClick={() => setOpenDeleteDialog(true)}
-                                    >
-                                        <Delete fontSize="small" />
-                                    </IconButton>
-                                </Tooltip>
-                            )}
                         {ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK && (
                             <Tooltip title="Undo" arrow placement="right">
                                 <span style={styleSpan}>
@@ -237,6 +225,34 @@ const PanelButtons = ({
                                 </span>
                             </Tooltip>
                         )}
+                        {ctx.currentObjectType !== ctx.OBJECT_TYPE_WEATHER &&
+                            ctx.currentObjectType !== ctx.OBJECT_TYPE_POI && (
+                                <Tooltip title="Download GPX" arrow placement="right">
+                                    <span style={styleSpan}>
+                                        <IconButton
+                                            variant="contained"
+                                            type="button"
+                                            disabled={isEmptyTrack(ctx.selectedGpxFile)}
+                                            onClick={() => downloadGpx(ctx)}
+                                        >
+                                            <Download fontSize="small" />
+                                        </IconButton>
+                                    </span>
+                                </Tooltip>
+                            )}
+                        {ctx.currentObjectType !== ctx.OBJECT_TYPE_WEATHER &&
+                            ctx.currentObjectType !== ctx.OBJECT_TYPE_POI && (
+                                <Tooltip title="Delete" arrow placement="right">
+                                    <IconButton
+                                        sx={{ mb: '1px' }}
+                                        variant="contained"
+                                        type="button"
+                                        onClick={() => setOpenDeleteDialog(true)}
+                                    >
+                                        <Delete fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
+                            )}
                         {ctx.currentObjectType && !infoBlockOpen && !mobile && (
                             <Tooltip title="Open info" arrow placement="right">
                                 <IconButton onClick={toggleInfoBlock} sx={{ transform: 'scaleX(1)' }}>

--- a/map/src/infoblock/components/PanelButtons.jsx
+++ b/map/src/infoblock/components/PanelButtons.jsx
@@ -31,12 +31,9 @@ const PanelButtons = ({
 
     const { state, setState, undo, redo, clear, isUndoPossible, isRedoPossible, pastStates } = useUndoRedo();
 
-    const isUndoDisabled =
-        ctx.processRouting || !isUndoPossible || (pastStates.length === 1 && _.isEmpty(pastStates[0]));
-
-    const isRedoDisabled = ctx.processRouting || !isRedoPossible;
-
-    const isProfileDisabled = ctx.processRouting;
+    const isUndoDisabled = !isUndoPossible || (pastStates.length === 1 && _.isEmpty(pastStates[0])); // || ctx.processRouting
+    const isRedoDisabled = !isRedoPossible; // || ctx.processRouting
+    const isProfileDisabled = false; // ctx.processRouting;
 
     useEffect(() => {
         if (clearState) {

--- a/map/src/infoblock/components/PanelButtons.jsx
+++ b/map/src/infoblock/components/PanelButtons.jsx
@@ -1,4 +1,4 @@
-import { ButtonGroup, IconButton, Paper, Tooltip } from '@mui/material';
+import { ButtonGroup, IconButton, Paper, Tooltip, CircularProgress } from '@mui/material';
 import { Close, Delete, CloudUpload, Redo, Undo, Create, MenuOpen } from '@mui/icons-material';
 import React, { useContext, useEffect, useState } from 'react';
 import AppContext from '../../context/AppContext';
@@ -28,6 +28,13 @@ const PanelButtons = ({
     };
 
     const { state, setState, undo, redo, clear, isUndoPossible, isRedoPossible, pastStates } = useUndoRedo();
+
+    const isUndoDisabled =
+        ctx.processRouting || !isUndoPossible || (pastStates.length === 1 && _.isEmpty(pastStates[0]));
+
+    const isRedoDisabled = ctx.processRouting || !isRedoPossible;
+
+    const isProfileDisabled = ctx.processRouting;
 
     useEffect(() => {
         if (clearState) {
@@ -128,14 +135,21 @@ const PanelButtons = ({
                         {ctx.createTrack && (
                             <Tooltip title="Change profile" arrow placement="right">
                                 <IconButton
+                                    sx={{ width: 40, height: 40 }}
                                     variant="contained"
                                     type="button"
                                     onClick={() => {
-                                        ctx.trackProfileManager.change = TracksManager.CHANGE_PROFILE_ALL;
-                                        ctx.setTrackProfileManager({ ...ctx.trackProfileManager });
+                                        if (!isProfileDisabled) {
+                                            ctx.trackProfileManager.change = TracksManager.CHANGE_PROFILE_ALL;
+                                            ctx.setTrackProfileManager({ ...ctx.trackProfileManager });
+                                        }
                                     }}
                                 >
-                                    {ctx.trackRouter.getProfile()?.icon}
+                                    {isProfileDisabled ? (
+                                        <CircularProgress size={40 - 16} />
+                                    ) : (
+                                        ctx.trackRouter.getProfile()?.icon
+                                    )}
                                 </IconButton>
                             </Tooltip>
                         )}
@@ -175,9 +189,7 @@ const PanelButtons = ({
                                     <IconButton
                                         variant="contained"
                                         type="button"
-                                        disabled={
-                                            !isUndoPossible || (pastStates.length === 1 && _.isEmpty(pastStates[0]))
-                                        }
+                                        disabled={isUndoDisabled}
                                         onClick={(e) => {
                                             undo();
                                             setUseSavedState(true);
@@ -195,7 +207,7 @@ const PanelButtons = ({
                                     <IconButton
                                         variant="contained"
                                         type="button"
-                                        disabled={!isRedoPossible}
+                                        disabled={isRedoDisabled}
                                         onClick={(e) => {
                                             redo();
                                             setUseSavedState(true);

--- a/map/src/infoblock/components/PanelButtons.jsx
+++ b/map/src/infoblock/components/PanelButtons.jsx
@@ -1,5 +1,5 @@
 import { ButtonGroup, IconButton, Paper, Tooltip, CircularProgress } from '@mui/material';
-import { Close, Delete, CloudUpload, Redo, Undo, Create, MenuOpen } from '@mui/icons-material';
+import { Close, Delete, Cloud, CloudUpload, Redo, Undo, Create, MenuOpen } from '@mui/icons-material';
 import React, { useContext, useEffect, useState } from 'react';
 import AppContext from '../../context/AppContext';
 import SaveTrackDialog from './track/dialogs/SaveTrackDialog';
@@ -8,6 +8,7 @@ import DeleteFavoriteDialog from './favorite/DeleteFavoriteDialog';
 import _ from 'lodash';
 import TracksManager, { isEmptyTrack } from '../../context/TracksManager';
 import useUndoRedo from '../useUndoRedo';
+import { confirm } from '../../dialogs/GlobalConfirmationDialog';
 
 const PanelButtons = ({
     orientation,
@@ -122,15 +123,32 @@ const PanelButtons = ({
                         color="primary"
                     >
                         {ctx.currentObjectType === ctx.OBJECT_TYPE_CLOUD_TRACK && (
-                            <Tooltip title="Edit" arrow placement="right">
-                                <IconButton
-                                    variant="contained"
-                                    type="button"
-                                    onClick={() => TracksManager.handleEditCloudTrack(ctx)}
-                                >
-                                    <Create fontSize="small" />
-                                </IconButton>
-                            </Tooltip>
+                            <>
+                                <Tooltip title="Cloud track" arrow placement="right">
+                                    <IconButton
+                                        variant="contained"
+                                        type="button"
+                                        onClick={() =>
+                                            confirm({
+                                                ctx,
+                                                text: 'This is Cloud track. Open editor?',
+                                                callback: () => TracksManager.handleEditCloudTrack(ctx),
+                                            })
+                                        }
+                                    >
+                                        <Cloud fontSize="medium" color="primary" />
+                                    </IconButton>
+                                </Tooltip>
+                                <Tooltip title="Edit" arrow placement="right">
+                                    <IconButton
+                                        variant="contained"
+                                        type="button"
+                                        onClick={() => TracksManager.handleEditCloudTrack(ctx)}
+                                    >
+                                        <Create fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
+                            </>
                         )}
                         {ctx.createTrack && (
                             <Tooltip title="Change profile" arrow placement="right">

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -30,6 +30,21 @@ import {
     Terrain,
 } from '@mui/icons-material';
 
+export const downloadGpx = async (ctx) => {
+    const gpx = await TracksManager.getGpxTrack(ctx.selectedGpxFile);
+    if (gpx) {
+        const data = gpx.data;
+        const url = document.createElement('a');
+        url.href = URL.createObjectURL(new Blob([data]));
+        const name = TracksManager.prepareName(
+            ctx.selectedGpxFile.name,
+            ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK
+        );
+        url.download = `${name}.gpx`;
+        url.click();
+    }
+};
+
 export default function GeneralInfo({ width, setOpenDescDialog }) {
     const styles = contextMenuStyles();
     const ctx = useContext(AppContext);
@@ -344,21 +359,6 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
         );
     };
 
-    const downloadGpx = async () => {
-        let gpx = await TracksManager.getGpxTrack(ctx.selectedGpxFile);
-        if (gpx) {
-            gpx = gpx.data;
-            const url = document.createElement('a');
-            url.href = URL.createObjectURL(new Blob([gpx]));
-            let name = TracksManager.prepareName(
-                ctx.selectedGpxFile.name,
-                ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK
-            );
-            url.download = `${name}.gpx`;
-            url.click();
-        }
-    };
-
     const Elevation = () => {
         return (
             <>
@@ -473,13 +473,7 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                     </Button>
                 )}
                 {isEmptyTrack(ctx.selectedGpxFile) === false && (
-                    <Button
-                        variant="contained"
-                        className={styles.button}
-                        onClick={() => {
-                            downloadGpx().then();
-                        }}
-                    >
+                    <Button variant="contained" className={styles.button} onClick={() => downloadGpx(ctx)}>
                         <Download fontSize="small" sx={{ mr: '3px' }} />
                         Download GPX
                     </Button>

--- a/map/src/infoblock/components/track/dialogs/ChangeProfileTrackDialog.jsx
+++ b/map/src/infoblock/components/track/dialogs/ChangeProfileTrackDialog.jsx
@@ -108,6 +108,17 @@ export default function ChangeProfileTrackDialog({ open }) {
         }
     }, [ctx.trackProfileManager?.pointInd]);
 
+    function updateLastPointProfile() {
+        const track = ctx.selectedGpxFile;
+        if (track.points?.length > 0) {
+            const last = track.points.length - 1;
+            if (track.points[last].profile !== TracksManager.PROFILE_GAP) {
+                track.points[last].geoProfile = geoProfile;
+                track.points[last].profile = geoProfile.profile;
+            }
+        }
+    }
+
     async function changeProfile() {
         if (!ctx.selectedGpxFile.layers) {
             return false; // on empty track
@@ -115,6 +126,7 @@ export default function ChangeProfileTrackDialog({ open }) {
         let polylines = TrackLayerProvider.getPolylines(ctx.selectedGpxFile.layers.getLayers());
         if (!partialEdit) {
             if (changeAll) {
+                // whole track - all segments
                 if (ctx.selectedGpxFile.points.length > 1) {
                     for (let i = 0; i < ctx.selectedGpxFile.points.length - 1; i++) {
                         const start = ctx.selectedGpxFile.points[i];
@@ -126,15 +138,19 @@ export default function ChangeProfileTrackDialog({ open }) {
                             TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
                         }
                     }
+                    updateLastPointProfile();
                     return true;
                 } else {
                     ctx.selectedGpxFile.points[0].geoProfile = geoProfile;
                     ctx.selectedGpxFile.points[0].profile = geoProfile.profile;
                     return true;
                 }
+            } else {
+                updateLastPointProfile(); // just update last point's profile
             }
         } else {
             if (changeOne) {
+                // before or after - one segment
                 let currentPoint = ctx.selectedGpxFile.points[ctx.trackProfileManager.pointInd];
                 let prevPoint = ctx.selectedGpxFile.points[ctx.trackProfileManager.pointInd - 1];
                 let nextPoint = ctx.selectedGpxFile.points[ctx.trackProfileManager.pointInd + 1];
@@ -164,6 +180,7 @@ export default function ChangeProfileTrackDialog({ open }) {
                     return true;
                 }
             } else if (changeAll) {
+                // before or after - all segments
                 if (ctx.trackProfileManager?.change === TracksManager.CHANGE_PROFILE_BEFORE) {
                     for (let i = 0; i < ctx.trackProfileManager.pointInd; i++) {
                         const start = ctx.selectedGpxFile.points[i];
@@ -187,6 +204,7 @@ export default function ChangeProfileTrackDialog({ open }) {
                             TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
                         }
                     }
+                    updateLastPointProfile();
                     return true;
                 }
             }

--- a/map/src/map/TrackLayerProvider.js
+++ b/map/src/map/TrackLayerProvider.js
@@ -16,7 +16,7 @@ function createLayersByTrackData(data, ctx) {
     let layers = [];
     data.tracks?.forEach((track) => {
         if (track.points?.length > 0) {
-            let res = parsePoints(track.points, layers, false, ctx);
+            let res = parsePoints({ ctx, points: track.points, layers, hidden: true });
             addStartEnd(track.points, layers, res.coordsTrk, res.coordsAll);
         }
     });
@@ -27,7 +27,7 @@ function createLayersByTrackData(data, ctx) {
     }
 }
 
-function parsePoints(points, layers, draggable, ctx) {
+function parsePoints({ ctx, points, layers, draggable = false, hidden = false }) {
     let coordsTrk = [];
     let coordsAll = [];
     points.forEach((point) => {
@@ -50,15 +50,18 @@ function parsePoints(points, layers, draggable, ctx) {
         }
     });
 
-    points.forEach((p) => {
-        if (draggable || (!draggable && p.geometry !== undefined)) {
-            let marker = new L.Marker(new L.LatLng(p.lat, p.lng), {
-                icon: MarkerOptions.options.route,
-                draggable: draggable,
-            });
-            layers.push(marker);
-        }
-    });
+    if (hidden === false) {
+        points.forEach((p) => {
+            if (draggable || (!draggable && p.geometry !== undefined)) {
+                const marker = new L.Marker(new L.LatLng(p.lat, p.lng), {
+                    icon: MarkerOptions.options.route,
+                    draggable: draggable,
+                    isRoutePoint: true,
+                });
+                layers.push(marker);
+            }
+        });
+    }
 
     let endPolyline = new L.Polyline(coordsTrk, getPolylineOpt());
     if (ctx) {

--- a/map/src/map/TrackLayerProvider.js
+++ b/map/src/map/TrackLayerProvider.js
@@ -12,11 +12,11 @@ const TEMP_LINE_STYLE = {
     name: TEMP_LAYER_FLAG,
 };
 
-function createLayersByTrackData(data) {
+function createLayersByTrackData(data, ctx) {
     let layers = [];
     data.tracks?.forEach((track) => {
         if (track.points?.length > 0) {
-            let res = parsePoints(track.points, layers);
+            let res = parsePoints(track.points, layers, false, ctx);
             addStartEnd(track.points, layers, res.coordsTrk, res.coordsAll);
         }
     });

--- a/map/src/map/components/OsmAndMap.jsx
+++ b/map/src/map/components/OsmAndMap.jsx
@@ -132,6 +132,8 @@ const OsmAndMap = ({ mobile, drawerRightHeight, mainMenuWidth, drawerRightWidth 
         document.addEventListener('touchend', markerEventHandler, { passive: false });
     }, []);
 
+    const routersReady = ctx.trackRouter.isReady() && ctx.routeRouter.isReady();
+
     return (
         <MapContainer
             center={position}
@@ -145,13 +147,13 @@ const OsmAndMap = ({ mobile, drawerRightHeight, mainMenuWidth, drawerRightWidth 
             contextmenuItems={[]}
             editable={true}
         >
-            <LocalClientTrackLayer />
-            <PoiLayer />
-            <RouteLayer geocodingData={geocodingData} region={regionData} />
+            {routersReady && <CloudTrackLayer />}
+            {routersReady && <LocalClientTrackLayer />}
+            {routersReady && <RouteLayer geocodingData={geocodingData} region={regionData} />}
             <FavoriteLayer />
             <WeatherLayer />
-            <CloudTrackLayer />
             <GraphLayer />
+            <PoiLayer />
             <TileLayer
                 ref={tileLayer}
                 attribution='WEB OsmAnd 0.1 &amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
@@ -160,7 +162,6 @@ const OsmAndMap = ({ mobile, drawerRightHeight, mainMenuWidth, drawerRightWidth 
                 maxNativeZoom={18}
                 url={ctx.tileURL.url}
             />
-
             {hoverPoint && (
                 <Marker ref={hoverPointRef} position={hoverPoint} icon={MarkerOptions.options.pointerGraph} />
             )}

--- a/map/src/map/components/OsmAndMap.jsx
+++ b/map/src/map/components/OsmAndMap.jsx
@@ -9,7 +9,7 @@ import L from 'leaflet';
 import 'leaflet-contextmenu';
 import 'leaflet-contextmenu/dist/leaflet.contextmenu.css';
 import FavoriteLayer from '../layers/FavoriteLayer';
-import TrackLayer from '../layers/TrackLayer';
+import CloudTrackLayer from '../layers/CloudTrackLayer';
 import LocalClientTrackLayer from '../layers/LocalClientTrackLayer';
 import MarkerOptions from '../markers/MarkerOptions';
 import ContextMenu from './ContextMenu';
@@ -150,7 +150,7 @@ const OsmAndMap = ({ mobile, drawerRightHeight, mainMenuWidth, drawerRightWidth 
             <RouteLayer geocodingData={geocodingData} region={regionData} />
             <FavoriteLayer />
             <WeatherLayer />
-            <TrackLayer />
+            <CloudTrackLayer />
             <GraphLayer />
             <TileLayer
                 ref={tileLayer}

--- a/map/src/map/layers/CloudTrackLayer.js
+++ b/map/src/map/layers/CloudTrackLayer.js
@@ -33,7 +33,7 @@ function removeLayerFromMap(file, map) {
     return null;
 }
 
-const TrackLayer = () => {
+const CloudTrackLayer = () => {
     const ctx = useContext(AppContext);
     const ctxTrack = ctx.selectedGpxFile;
 
@@ -109,4 +109,4 @@ const TrackLayer = () => {
     }, [ctx.gpxFiles]);
 };
 
-export default TrackLayer;
+export default CloudTrackLayer;

--- a/map/src/map/layers/CloudTrackLayer.js
+++ b/map/src/map/layers/CloudTrackLayer.js
@@ -6,7 +6,7 @@ import TracksManager from '../../context/TracksManager';
 import { useMutator } from '../../util/Utils';
 
 function addTrackToMap({ ctx, file, map, fit = true } = {}) {
-    const layer = TrackLayerProvider.createLayersByTrackData(file);
+    const layer = TrackLayerProvider.createLayersByTrackData(file, ctx);
 
     layer.on('click', () => {
         file.analysis = TracksManager.prepareAnalysis(file.analysis);

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -903,6 +903,8 @@ export default function LocalClientTrackLayer() {
 
         ctx.setSelectedGpxFile({ ...ctxTrack });
 
+        saveCreatedLayers(ctxTrack.layers);
+
         TracksManager.updateState(ctx);
     }
 

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -477,11 +477,6 @@ export default function LocalClientTrackLayer() {
                                 dashArray: null,
                             });
 
-                            setQueueForRouting((prev) => ({
-                                isProcessing: false,
-                                objs: prev.objs,
-                            }));
-
                             const analysis = () => {
                                 TracksManager.getTrackWithAnalysis(
                                     TracksManager.GET_ANALYSIS,
@@ -495,17 +490,23 @@ export default function LocalClientTrackLayer() {
 
                             debouncer(analysis, debouncerTimer, GET_ANALYSIS_DEBOUNCE_MS);
                         }
+
+                        // finally
+                        if (newObjs.length === 0) ctx.setProcessRouting(false);
+                        setQueueForRouting((prev) => ({
+                            isProcessing: false,
+                            objs: prev.objs,
+                        }));
+                        saveChanges(null, null, null, newFile);
                     })
             );
+            // process next queue
             const newObjs = queueForRouting.objs.slice(1);
             const newQueue = {
                 isProcessing: true,
                 objs: newObjs,
             };
             setQueueForRouting(() => newQueue);
-
-            if (newObjs.length === 0) ctx.setProcessRouting(false);
-            saveChanges(null, null, null, newFile); // finally, after promises
         }
     }, [queueForRouting]);
 

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -675,7 +675,7 @@ export default function LocalClientTrackLayer() {
         if (trackLayers) {
             let layers = [];
             if (points?.length > 0) {
-                TrackLayerProvider.parsePoints(points, layers, true, ctx);
+                TrackLayerProvider.parsePoints({ ctx, points, layers, draggable: true });
             }
             if (wpts?.length > 0) {
                 TrackLayerProvider.parseWpt(wpts, layers);

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -347,7 +347,7 @@ export default function LocalClientTrackLayer() {
         if (track.updated) {
             track.updated = false; // reset
         }
-        let layer = TrackLayerProvider.createLayersByTrackData(track);
+        let layer = TrackLayerProvider.createLayersByTrackData(track, ctx);
         if (layer) {
             if (fitBounds) {
                 if (!_.isEmpty(layer.getBounds())) {
@@ -609,7 +609,7 @@ export default function LocalClientTrackLayer() {
         TracksManager.prepareTrack(file);
 
         file.tracks = [{ points, wpts }];
-        file.layers = TrackLayerProvider.createLayersByTrackData(file);
+        file.layers = TrackLayerProvider.createLayersByTrackData(file, ctx);
 
         ctx.localTracks.push(file);
         ctx.setLocalTracks([...ctx.localTracks]);

--- a/map/src/setupProxy.js
+++ b/map/src/setupProxy.js
@@ -1,21 +1,50 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function (app) {
-    const proxy = createProxyMiddleware({
-        target:
-            process.env.NODE_ENV === 'development'
-                ? 'https://test.osmand.net/' // https
-                : 'http://localhost:8080/',
-        changeOrigin: true,
-        hostRewrite: 'localhost:3000',
-        logLevel: 'debug',
-    });
-    app.use('/mapapi/', proxy);
-    app.use('/routing/', proxy);
-    app.use('/search/', proxy);
-    app.use('/gpx/', proxy);
-    app.use('/tile/', proxy);
-    app.use('/weather-api/', proxy);
-    app.use('/online-routing-providers.json', proxy); // osrm
-    app.use('/weather/', proxy);
+    const prepare = (target) => ({ target, hostRewrite: 'localhost:3000', changeOrigin: true, logLevel: 'debug' });
+
+    const localProxy = createProxyMiddleware(prepare('http://localhost:8080'));
+
+    const testProxy = createProxyMiddleware(prepare('https://test.osmand.net'));
+
+    const mainProxy = createProxyMiddleware(prepare('https://osmand.net'));
+    const maptileProxy = createProxyMiddleware(prepare('https://maptile.osmand.net'));
+
+    let gpx = localProxy;
+    let tile = localProxy;
+    let mapapi = localProxy;
+    let routing = localProxy;
+    let weather = localProxy;
+    let others = localProxy;
+
+    // yarn start (test)
+    if (process.env.NODE_ENV === 'development') {
+        gpx = testProxy;
+        tile = testProxy;
+        mapapi = testProxy;
+        routing = testProxy;
+        weather = testProxy;
+        others = testProxy;
+    }
+
+    // yarn start:fallback (prod)
+    if (process.env.USE_MAIN_API) {
+        gpx = maptileProxy;
+        tile = maptileProxy;
+        routing = maptileProxy;
+
+        weather = testProxy;
+
+        mapapi = mainProxy;
+        others = mainProxy;
+    }
+
+    app.use('/gpx/', gpx);
+    app.use('/tile/', tile);
+    app.use('/mapapi/', mapapi);
+    app.use('/routing/', routing);
+    app.use('/weather-api/', weather);
+    // app.use('/weather/', weather); // defined-by-env
+    // app.use('/search/', others); // actually /routing/search
+    app.use('/online-routing-providers.json', others); // osrm-providers
 };

--- a/map/src/store/geoRouter/methods/loadProviders.js
+++ b/map/src/store/geoRouter/methods/loadProviders.js
@@ -16,7 +16,7 @@ function getColors() {
         horsebackriding: '#7f3431',
         pedestrian: '#d90139',
         ski: '#ffacdf',
-        [PROFILE_LINE]: '#5F9EA0',
+        [PROFILE_LINE]: '#2F6E80',
         moped: '#3e690e',
         train: '#a56b6f',
         rescuetrack: '#0000ff',


### PR DESCRIPTION
- [x] test: panel buttons - test Download GPX button (both Cloud and Local tracks)

- [x] test: panel buttons - new Cloud icon for Cloud tracks (also test click this button)

- [x] test: panel buttons - Undo/Redo/Profile buttons are disabled when route has been calculating

- [x] test: improved saving of last selected profile (test on recalc All segments, on just change "Next" profile)

- [x] test: Cloud tracks and Visible Local Tracks should be multi-colored according to profile colors

- [x] test: View-mode tracks (Cloud and Local) should have no visible route-points

- [x] test: Line-profile color contrast improved, test on different map places

