### PR TITLE
Improve points[].geometry[] distance recalculation, fix local-cloud and gpx duplicated geometry #2179

### DIFF
--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -471,7 +471,9 @@ function addDistanceToPoints(points) {
                 geo[0].distance = 0;
                 if (geo.length > 1) {
                     for (let i = 1; i < geo.length; i++) {
-                        geo[i].distance = Utils.getDistance(geo[i - 1].lat, geo[i - 1].lng, geo[i].lat, geo[i].lng);
+                        const dist = Utils.getDistance(geo[i - 1].lat, geo[i - 1].lng, geo[i].lat, geo[i].lng);
+                        geo[i].distance = dist;
+                        point.dist += dist;
                     }
                 }
             }

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -225,6 +225,34 @@ function getGroup(name, local) {
     }
 }
 
+function deduplicateTrackTracksPointsGeometryPoints(track) {
+    if (track && track.tracks) {
+        track.tracks?.forEach((t) =>
+            t.points?.forEach((p) => {
+                /**
+                 * Check distinct point's geometry for duplicates.
+                 * Overwrite this geometry with newly created points.
+                 */
+                if (p.geometry) {
+                    const newGeo = [];
+                    let lastLat = null;
+                    let lastLng = null;
+                    const oldGeo = p.geometry;
+                    for (let i = 0; i < oldGeo.length; i++) {
+                        if (oldGeo[i].lat === lastLat && oldGeo[i].lng === lastLng) {
+                            continue;
+                        }
+                        newGeo.push(oldGeo[i]);
+                        lastLat = oldGeo[i].lat;
+                        lastLng = oldGeo[i].lng;
+                    }
+                    p.geometry = newGeo; // mutate
+                }
+            })
+        );
+    }
+}
+
 async function getTrackData(file) {
     let formData = new FormData();
     formData.append('file', file);
@@ -242,6 +270,7 @@ async function getTrackData(file) {
             let data = JSON.parse(quickNaNfix(resp));
             if (data) {
                 track = data.gpx_data;
+                deduplicateTrackTracksPointsGeometryPoints(track);
             }
         }
     }

--- a/map/src/drawer/components/tracks/LocalTrackItem.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackItem.jsx
@@ -50,6 +50,7 @@ export default function LocalTrackItem({ track }) {
         ref.selected = true;
         ref.zoom = true;
         ref.analysis = TracksManager.prepareAnalysis(ref.analysis);
+        TracksManager.addDistance(ref); // recalc-distance-local
         ctx.setLocalTracks([...ctx.localTracks]);
         ctx.setSelectedGpxFile({ ...track });
     }

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -104,11 +104,10 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
     }
 
     function getPoints() {
-        if (ctx.selectedGpxFile.points) {
-            setPoints(ctx.selectedGpxFile.points.length);
-        } else {
-            setPoints(TracksManager.getEditablePoints(ctx.selectedGpxFile).length);
-        }
+        let geoPoints = 0;
+        const points = ctx.selectedGpxFile.points ?? TracksManager.getEditablePoints(ctx.selectedGpxFile);
+        points?.forEach((p) => (geoPoints += p.geometry?.length ?? 0));
+        setPoints(`${points?.length ?? 0} (${geoPoints})`);
     }
 
     function getTimeRange(info) {


### PR DESCRIPTION
- [ ] test: try to repeat "charts-broken-segments" bugs (the bug activated always after uploading to Cloud or re-using Downloaded GPX file)

- [ ] test: create track, do 10 cycles: Local-Cloud...Local-Cloud, every time use download gpx, finally all downloaded gpx should have same size