### PR TITLE
Improve addDistance() recalculation (segments/total), fix little distance-related bugs, drop outdated code

### DIFF
--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -145,7 +145,7 @@ function prepareLocalTrack(track) {
         id: prepareTrack.id,
         metaData: prepareTrack.metaData,
         points: prepareTrack.points,
-        // tracks: prepareTrack.tracks, // now tracks[] is not needed for localTracks
+        // tracks: prepareTrack.tracks, // tracks[] will be back
         wpts: prepareTrack.wpts,
         pointsGroups: prepareTrack.pointsGroups,
         ext: prepareTrack.ext,

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -471,7 +471,9 @@ function addDistanceToPoints(points) {
                 geo[0].distance = 0;
                 if (geo.length > 1) {
                     for (let i = 1; i < geo.length; i++) {
-                        geo[i].distance = Utils.getDistance(geo[i - 1].lat, geo[i - 1].lng, geo[i].lat, geo[i].lng);
+                        const dist = Utils.getDistance(geo[i - 1].lat, geo[i - 1].lng, geo[i].lat, geo[i].lng);
+                        geo[i].distance = dist;
+                        point.dist += dist;
                     }
                 }
             }

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -226,35 +226,6 @@ function getGroup(name, local) {
     }
 }
 
-// function deduplicateTrackTracksPointsGeometryPoints(track) {
-//     // was used temporarily in getTrackData()
-//     if (track && track.tracks) {
-//         track.tracks?.forEach((t) =>
-//             t.points?.forEach((p) => {
-//                 /**
-//                  * Check distinct point's geometry for duplicates.
-//                  * Overwrite this geometry with newly created points.
-//                  */
-//                 if (p.geometry) {
-//                     const newGeo = [];
-//                     let lastLat = null;
-//                     let lastLng = null;
-//                     const oldGeo = p.geometry;
-//                     for (let i = 0; i < oldGeo.length; i++) {
-//                         if (oldGeo[i].lat === lastLat && oldGeo[i].lng === lastLng) {
-//                             continue;
-//                         }
-//                         newGeo.push(oldGeo[i]);
-//                         lastLat = oldGeo[i].lat;
-//                         lastLng = oldGeo[i].lng;
-//                     }
-//                     p.geometry = newGeo; // mutate
-//                 }
-//             })
-//         );
-//     }
-// }
-
 async function getTrackData(file) {
     let formData = new FormData();
     formData.append('file', file);
@@ -460,21 +431,8 @@ function addDistanceToPoints(points) {
             point.dist = 0;
 
             point.geometry.forEach((p) => {
-                point.dist += p.distance;
+                point.dist += p.distance; // p.distance is set by API process-track-data
             });
-
-            // if (point.geometry.length > 0) {
-            //     // recalc geometry distance (tmp)
-            //     const geo = point.geometry; // ref
-            //     geo[0].distance = 0;
-            //     if (geo.length > 1) {
-            //         for (let i = 1; i < geo.length; i++) {
-            //             const dist = Utils.getDistance(geo[i - 1].lat, geo[i - 1].lng, geo[i].lat, geo[i].lng);
-            //             geo[i].distance = dist;
-            //             point.dist += dist;
-            //         }
-            //     }
-            // }
 
             distanceTotal += point.dist;
             distanceSegment += point.dist;
@@ -729,74 +687,6 @@ function updateGapProfileOneSegment(routePoint, points) {
         points[points.length - 1].profile = PROFILE_GAP;
     }
 }
-
-// function updateStat(track) {
-//     addDistance(track);
-//     let activePoints = track.points;
-//     if (track.analysis?.totalDistance) {
-//         track.analysis.totalDistance = activePoints[activePoints.length - 1].distanceTotal;
-//     }
-//     track.analysis.timeMoving = null;
-//     track.analysis.diffElevationUp = null;
-//     track.analysis.diffElevationDown = null;
-//     if (track.analysis.hasSpeedData) {
-//         let totalSpeedSum = 0;
-//         let speedCount = 0;
-//         for (let t of track.tracks) {
-//             for (let p of t.points) {
-//                 if (p.geometry) {
-//                     for (let g of p.geometry) {
-//                         let speed = g.ext.speed;
-//                         track.analysis.minSpeed = Math.min(speed, track.analysis.minSpeed);
-//                         if (speed > 0) {
-//                             totalSpeedSum += speed;
-//                             track.analysis.maxSpeed = Math.max(speed, track.analysis.maxSpeed);
-//                             speedCount++;
-//                         }
-//                     }
-//                 } else {
-//                     let speed = p.ext.speed;
-//                     track.analysis.minSpeed = Math.min(speed, track.analysis.minSpeed);
-//                     if (speed > 0) {
-//                         totalSpeedSum += speed;
-//                         track.analysis.maxSpeed = Math.max(speed, track.analysis.maxSpeed);
-//                         speedCount++;
-//                     }
-//                 }
-//             }
-//         }
-//         track.analysis.avgSpeed = totalSpeedSum / speedCount;
-//     }
-
-//     if (track.analysis.hasElevationData) {
-//         let totalEleSum = 0;
-//         let eleCount = 0;
-//         for (let t of track.tracks) {
-//             for (let p of t.points) {
-//                 if (p.geometry) {
-//                     for (let g of p.geometry) {
-//                         let ele = getEle(g, 'ele', p.geometry);
-//                         track.analysis.minElevation = Math.min(ele, track.analysis.minElevation);
-//                         if (ele > 0) {
-//                             totalEleSum += ele;
-//                             track.analysis.maxElevation = Math.max(ele, track.analysis.maxElevation);
-//                             eleCount++;
-//                         }
-//                     }
-//                 } else {
-//                     let ele = getEle(p, 'ele', t.points);
-//                     track.analysis.minElevation = Math.min(ele, track.analysis.minElevation);
-//                     if (ele > 0) {
-//                         totalEleSum += ele;
-//                         track.analysis.maxElevation = Math.max(ele, track.analysis.maxElevation);
-//                         eleCount++;
-//                     }
-//                 }
-//             }
-//         }
-//         track.analysis.avgElevation = totalEleSum / eleCount;
-//     }
-// }
 
 function getEle(point, elevation, array) {
     let ele = point[elevation];
@@ -1146,7 +1036,6 @@ const TracksManager = {
     getEditablePoints,
     updateGapProfileOneSegment,
     updateRoute,
-    // updateStat,
     getEle,
     deleteLocalTrack,
     createName,

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -225,6 +225,34 @@ function getGroup(name, local) {
     }
 }
 
+function deduplicateTrackTracksPointsGeometryPoints(track) {
+    if (track && track.tracks) {
+        track.tracks?.forEach((t) =>
+            t.points?.forEach((p) => {
+                /**
+                 * Check distinct point's geometry for duplicates.
+                 * Overwrite this geometry with newly created points.
+                 */
+                if (p.geometry) {
+                    const newGeo = [];
+                    let lastLat = null;
+                    let lastLng = null;
+                    const oldGeo = p.geometry;
+                    for (let i = 0; i < oldGeo.length; i++) {
+                        if (oldGeo[i].lat === lastLat && oldGeo[i].lng === lastLng) {
+                            continue;
+                        }
+                        newGeo.push(oldGeo[i]);
+                        lastLat = oldGeo[i].lat;
+                        lastLng = oldGeo[i].lng;
+                    }
+                    p.geometry = newGeo; // mutate
+                }
+            })
+        );
+    }
+}
+
 async function getTrackData(file) {
     let formData = new FormData();
     formData.append('file', file);
@@ -242,6 +270,7 @@ async function getTrackData(file) {
             let data = JSON.parse(quickNaNfix(resp));
             if (data) {
                 track = data.gpx_data;
+                deduplicateTrackTracksPointsGeometryPoints(track);
             }
         }
     }

--- a/map/src/drawer/components/tracks/LocalTrackItem.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackItem.jsx
@@ -50,6 +50,7 @@ export default function LocalTrackItem({ track }) {
         ref.selected = true;
         ref.zoom = true;
         ref.analysis = TracksManager.prepareAnalysis(ref.analysis);
+        TracksManager.addDistance(ref); // recalc-distance-local
         ctx.setLocalTracks([...ctx.localTracks]);
         ctx.setSelectedGpxFile({ ...track });
     }

--- a/map/src/drawer/components/tracks/TracksMenu.jsx
+++ b/map/src/drawer/components/tracks/TracksMenu.jsx
@@ -102,6 +102,8 @@ export default function TracksMenu() {
             if (item.local !== true && item.analysis && item.url) {
                 if (item.analysis.totalTracks) {
                     tracks += item.analysis.totalTracks;
+                } else {
+                    tracks++;
                 }
                 if (item.analysis.points) {
                     seg += item.analysis.points - 1;
@@ -126,6 +128,8 @@ export default function TracksMenu() {
             if (item.local === true && item.analysis && item.url) {
                 if (item.analysis.totalTracks) {
                     tracks += item.analysis.totalTracks;
+                } else {
+                    tracks++;
                 }
                 if (item.analysis.wptPoints) {
                     wpts += item.analysis.wptPoints;

--- a/map/src/infoblock/components/tabs/PointsTab.jsx
+++ b/map/src/infoblock/components/tabs/PointsTab.jsx
@@ -54,7 +54,7 @@ const PointsTab = ({ width }) => {
     });
 
     function getPoints() {
-        return ctx.selectedGpxFile.points ?? []; // distance already exists
+        return ctx.selectedGpxFile.points ?? []; // distance is already exist
     }
 
     function deleteAllPoints() {

--- a/map/src/infoblock/components/tabs/PointsTab.jsx
+++ b/map/src/infoblock/components/tabs/PointsTab.jsx
@@ -54,11 +54,7 @@ const PointsTab = ({ width }) => {
     });
 
     function getPoints() {
-        let points = ctx.selectedGpxFile?.points;
-        if (points) {
-            TracksManager.addDistanceToPoints(points);
-            return points;
-        }
+        return ctx.selectedGpxFile.points ?? []; // distance already exists
     }
 
     function deleteAllPoints() {

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -104,10 +104,8 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
     }
 
     function getPoints() {
-        let geoPoints = 0;
         const points = ctx.selectedGpxFile.points ?? TracksManager.getEditablePoints(ctx.selectedGpxFile);
-        points?.forEach((p) => (geoPoints += p.geometry?.length ?? 0));
-        setPoints(`${points?.length ?? 0} (${geoPoints})`);
+        setPoints(points?.length ?? 0);
     }
 
     function getTimeRange(info) {

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -104,11 +104,10 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
     }
 
     function getPoints() {
-        if (ctx.selectedGpxFile.points) {
-            setPoints(ctx.selectedGpxFile.points.length);
-        } else {
-            setPoints(TracksManager.getEditablePoints(ctx.selectedGpxFile).length);
-        }
+        let geoPoints = 0;
+        const points = ctx.selectedGpxFile.points ?? TracksManager.getEditablePoints(ctx.selectedGpxFile);
+        points?.forEach((p) => (geoPoints += p.geometry?.length ?? 0));
+        setPoints(`${points?.length ?? 0} (${geoPoints})`);
     }
 
     function getTimeRange(info) {

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -560,10 +560,7 @@ export default function LocalClientTrackLayer() {
             ctxTrack.wpts = wpts;
             ctxTrack.layers = layers;
         }
-        TracksManager.addDistance(ctxTrack);
-        if (ctxTrack.points) {
-            TracksManager.addDistanceToPoints(ctxTrack.points);
-        }
+        TracksManager.addDistance(ctxTrack); // recalc-distance-local-save
         saveCreatedLayers(ctxTrack.layers);
         ctxTrack.zoom = false;
         ctx.setSelectedGpxFile({ ...ctxTrack });


### PR DESCRIPTION
- [ ] test: try to repeat "charts-broken-segments" bugs (the bug was activated always after uploading to Cloud or re-using Downloaded GPX file)

- [ ] test: create track, do 5 cycles: Local-Cloud...Local-Cloud, every time use download gpx, finally all downloaded gpx should have same size

- [ ] test: header stats for Selected tracks should work both for Local and Cloud selected tracks