### PR TITLE
GPX-segments (after routed-segments added): protect against bulk re-routing, allow drag-drop new point, fix NaN in track points distance

### DIFF
--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -658,35 +658,6 @@ function decodeRouteMode({ routeMode, params }) {
     return draft;
 }
 
-// async function updateRoute(points) {
-//     let result;
-//     if (points?.length > 0) {
-//         result = await apiGet(`${process.env.REACT_APP_GPX_API}/routing/get-route`, {
-//             method: 'POST',
-//             data: points,
-//         });
-//     }
-//     if (result && result.data) {
-//         let data = result.data; // points
-//         if (typeof result.data === 'string') {
-//             data = JSON.parse(quickNaNfix(result.data));
-//         }
-//         updateGapProfileAllSegments(data.points);
-//         return data.points;
-//     } else {
-//         console.error('updateRoute fallback');
-//         return points;
-//     }
-// }
-
-// function updateGapProfileAllSegments(points) {
-//     if (points) {
-//         points.forEach((p) => {
-//             updateGapProfileOneSegment(p, p.geometry);
-//         });
-//     }
-// }
-
 function updateGapProfileOneSegment(routePoint, points) {
     if (routePoint.profile === PROFILE_GAP) {
         points[points.length - 1].profile = PROFILE_GAP;
@@ -1076,7 +1047,6 @@ const TracksManager = {
     saveTrack,
     getEditablePoints,
     updateGapProfileOneSegment,
-    // updateRoute,
     getEle,
     deleteLocalTrack,
     createName,

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -429,12 +429,14 @@ function addDistanceToPoints(points) {
                 if (geo.length > 1) {
                     for (let i = 1; i < geo.length; i++) {
                         // keep original if possible
-                        if (geo[i].distance === 0) {
+                        if (geo[i].distance === 0 || geo[i].distance === undefined) {
                             const current = geo[i];
                             const previous = geo[i - 1];
                             geo[i].distance = Utils.getDistance(current.lat, current.lng, previous.lat, previous.lng);
                         }
-                        point.dist += geo[i].distance;
+                        if (geo[i].distance > 0) {
+                            point.dist += geo[i].distance;
+                        }
                     }
                 }
             }

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -1012,6 +1012,33 @@ export function isPointUnrouted({ point, pointIndex, prevPoint }) {
     );
 }
 
+export function isProtectedSegment({ startPoint, endPoint }) {
+    if (!startPoint || !endPoint) {
+        console.error('isProtectedSegment got empty point');
+        return true;
+    }
+
+    // gpx (just loaded)
+    if (!endPoint.geometry && !startPoint.profile) {
+        // console.debug('protect-gpx-plain');
+        return true;
+    }
+
+    // gpx (after routing): protect Line-segments with more-than-line geometry
+    if (startPoint.profile === PROFILE_LINE && endPoint.geometry?.length > 2) {
+        // console.debug('protect-gpx-geometry');
+        return true;
+    }
+
+    // gap-profile should be protected
+    if (startPoint.profile === PROFILE_GAP) {
+        // console.debug('protect-gap-profile');
+        return true;
+    }
+
+    return false;
+}
+
 function showSelectedPointOnMap(ctxTrack, map, selectedPointMarker, setSelectedPointMarker) {
     if (ctxTrack?.showPoint?.layer) {
         map.setView([ctxTrack.showPoint.layer._latlng.lat, ctxTrack.showPoint.layer._latlng.lng], 17);

--- a/map/src/context/TracksRoutingCache.js
+++ b/map/src/context/TracksRoutingCache.js
@@ -150,6 +150,9 @@ function dropOutdatedCache({ ctx, validKeys, killLayers = false }) {
 
 // add start-end segment to cache, re-use cached geometry
 function addRoutingToCache(startPoint, endPoint, tempLine, ctx) {
+    if (tempLine === null) {
+        return; // protected segment
+    }
     const geoProfile = ctx.trackRouter.getGeoProfile(startPoint);
     const routingKey = createRoutingKey(startPoint, endPoint, geoProfile);
     const cachedGeometry = ctx.routingCache[routingKey]?.geometry ?? null;

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -30,7 +30,6 @@ import {
     Speed,
     Terrain,
 } from '@mui/icons-material';
-import _ from 'lodash';
 
 export const downloadGpx = async (ctx) => {
     const gpx = await TracksManager.getGpxTrack(ctx.selectedGpxFile);
@@ -247,13 +246,15 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                 currentTrack.name = newName;
             }
 
-            // cleanup (close) previous selectedGpxFile because the name was changed and we have a new file
-            ctx.setCreateTrack({ ...ctx.createTrack, closePrev: { file: _.cloneDeep(ctx.selectedGpxFile) } });
-
             ctx.selectedGpxFile.name = newName;
 
+            // track rename have to be finished correctly in the editor component
+            ctx.selectedGpxFile.oldName = oldName; // used by effect in LocalClientTrackLayer
+
             TracksManager.saveTracks({ ctx, track: ctx.selectedGpxFile }); // ctx.localTracks might be modified there
+
             ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
+
             ctx.setLocalTracks([...ctx.localTracks]);
 
             setEnableEditName(false);

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -30,6 +30,7 @@ import {
     Speed,
     Terrain,
 } from '@mui/icons-material';
+import _ from 'lodash';
 
 export const downloadGpx = async (ctx) => {
     const gpx = await TracksManager.getGpxTrack(ctx.selectedGpxFile);
@@ -245,6 +246,9 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
             if (currentTrack) {
                 currentTrack.name = newName;
             }
+
+            // cleanup (close) previous selectedGpxFile because the name was changed and we have a new file
+            ctx.setCreateTrack({ ...ctx.createTrack, closePrev: { file: _.cloneDeep(ctx.selectedGpxFile) } });
 
             ctx.selectedGpxFile.name = newName;
 

--- a/map/src/infoblock/components/track/dialogs/ChangeProfileTrackDialog.jsx
+++ b/map/src/infoblock/components/track/dialogs/ChangeProfileTrackDialog.jsx
@@ -132,10 +132,18 @@ export default function ChangeProfileTrackDialog({ open }) {
                         const start = ctx.selectedGpxFile.points[i];
                         const end = ctx.selectedGpxFile.points[i + 1];
                         if (start.profile !== TracksManager.PROFILE_GAP) {
-                            start.geoProfile = geoProfile;
-                            start.profile = geoProfile.profile;
-                            let currentPolyline = TrackLayerProvider.updatePolyline(start, end, polylines, start, end);
-                            TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
+                            const currentPolyline = TrackLayerProvider.updatePolyline(
+                                start,
+                                end,
+                                polylines,
+                                start,
+                                end
+                            );
+                            if (currentPolyline) {
+                                start.geoProfile = geoProfile;
+                                start.profile = geoProfile.profile;
+                                TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
+                            }
                         }
                     }
                     updateLastPointProfile();
@@ -155,28 +163,32 @@ export default function ChangeProfileTrackDialog({ open }) {
                 let prevPoint = ctx.selectedGpxFile.points[ctx.trackProfileManager.pointInd - 1];
                 let nextPoint = ctx.selectedGpxFile.points[ctx.trackProfileManager.pointInd + 1];
                 if (ctx.trackProfileManager?.change === TracksManager.CHANGE_PROFILE_BEFORE) {
-                    prevPoint.geoProfile = geoProfile;
-                    prevPoint.profile = geoProfile.profile;
-                    let currentPolyline = TrackLayerProvider.updatePolyline(
+                    const currentPolyline = TrackLayerProvider.updatePolyline(
                         prevPoint,
                         currentPoint,
                         polylines,
                         prevPoint,
                         currentPoint
                     );
-                    TracksRoutingCache.addRoutingToCache(prevPoint, currentPoint, currentPolyline, ctx);
+                    if (currentPolyline) {
+                        prevPoint.geoProfile = geoProfile;
+                        prevPoint.profile = geoProfile.profile;
+                        TracksRoutingCache.addRoutingToCache(prevPoint, currentPoint, currentPolyline, ctx);
+                    }
                     return true;
                 } else if (ctx.trackProfileManager?.change === TracksManager.CHANGE_PROFILE_AFTER) {
-                    currentPoint.geoProfile = geoProfile;
-                    currentPoint.profile = geoProfile.profile;
-                    let currentPolyline = TrackLayerProvider.updatePolyline(
+                    const currentPolyline = TrackLayerProvider.updatePolyline(
                         currentPoint,
                         nextPoint,
                         polylines,
                         currentPoint,
                         nextPoint
                     );
-                    TracksRoutingCache.addRoutingToCache(currentPoint, nextPoint, currentPolyline, ctx);
+                    if (currentPolyline) {
+                        currentPoint.geoProfile = geoProfile;
+                        currentPoint.profile = geoProfile.profile;
+                        TracksRoutingCache.addRoutingToCache(currentPoint, nextPoint, currentPolyline, ctx);
+                    }
                     return true;
                 }
             } else if (changeAll) {
@@ -186,10 +198,18 @@ export default function ChangeProfileTrackDialog({ open }) {
                         const start = ctx.selectedGpxFile.points[i];
                         const end = ctx.selectedGpxFile.points[i + 1];
                         if (start.profile !== TracksManager.PROFILE_GAP) {
-                            start.geoProfile = geoProfile;
-                            start.profile = geoProfile.profile;
-                            let currentPolyline = TrackLayerProvider.updatePolyline(start, end, polylines, start, end);
-                            TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
+                            const currentPolyline = TrackLayerProvider.updatePolyline(
+                                start,
+                                end,
+                                polylines,
+                                start,
+                                end
+                            );
+                            if (currentPolyline) {
+                                start.geoProfile = geoProfile;
+                                start.profile = geoProfile.profile;
+                                TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
+                            }
                         }
                     }
                     return true;
@@ -198,10 +218,18 @@ export default function ChangeProfileTrackDialog({ open }) {
                         const start = ctx.selectedGpxFile.points[i];
                         const end = ctx.selectedGpxFile.points[i + 1];
                         if (start.profile !== TracksManager.PROFILE_GAP) {
-                            start.geoProfile = geoProfile;
-                            start.profile = geoProfile.profile;
-                            let currentPolyline = TrackLayerProvider.updatePolyline(start, end, polylines, start, end);
-                            TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
+                            const currentPolyline = TrackLayerProvider.updatePolyline(
+                                start,
+                                end,
+                                polylines,
+                                start,
+                                end
+                            );
+                            if (currentPolyline) {
+                                start.geoProfile = geoProfile;
+                                start.profile = geoProfile.profile;
+                                TracksRoutingCache.addRoutingToCache(start, end, currentPolyline, ctx);
+                            }
                         }
                     }
                     updateLastPointProfile();

--- a/map/src/infoblock/components/track/dialogs/ChangeProfileTrackDialog.jsx
+++ b/map/src/infoblock/components/track/dialogs/ChangeProfileTrackDialog.jsx
@@ -149,8 +149,10 @@ export default function ChangeProfileTrackDialog({ open }) {
                     updateLastPointProfile();
                     return true;
                 } else {
-                    ctx.selectedGpxFile.points[0].geoProfile = geoProfile;
-                    ctx.selectedGpxFile.points[0].profile = geoProfile.profile;
+                    if (ctx.selectedGpxFile.points?.length > 0) {
+                        ctx.selectedGpxFile.points[0].geoProfile = geoProfile;
+                        ctx.selectedGpxFile.points[0].profile = geoProfile.profile;
+                    }
                     return true;
                 }
             } else {

--- a/map/src/map/EditableMarker.js
+++ b/map/src/map/EditableMarker.js
@@ -152,7 +152,6 @@ export default class EditableMarker {
                             newGeo[newGeo.length - 1] = { lat: currentPoint.lat, lng: currentPoint.lng };
                             currentPoint.geometry = newGeo;
                         } else {
-                            currentPoint.geometry = []; // ready for updateLayers
                             currentPolyline = TrackLayerProvider.updatePolyline(
                                 prevPoint,
                                 currentPoint,
@@ -160,13 +159,16 @@ export default class EditableMarker {
                                 null,
                                 oldPoint
                             );
-                            segments = TracksRoutingCache.addSegmentToRouting(
-                                prevPoint,
-                                currentPoint,
-                                null, // oldPoint,
-                                currentPolyline,
-                                segments
-                            );
+                            if (currentPolyline) {
+                                currentPoint.geometry = []; // ready for updateLayers
+                                segments = TracksRoutingCache.addSegmentToRouting(
+                                    prevPoint,
+                                    currentPoint,
+                                    null, // oldPoint,
+                                    currentPolyline,
+                                    segments
+                                );
+                            }
                         }
                     }
                 }
@@ -179,7 +181,6 @@ export default class EditableMarker {
                             newGeo[0] = { lat: currentPoint.lat, lng: currentPoint.lng };
                             nextPoint.geometry = newGeo;
                         } else {
-                            nextPoint.geometry = []; // ready for updateLayers
                             nextPolyline = TrackLayerProvider.updatePolyline(
                                 currentPoint,
                                 nextPoint,
@@ -187,13 +188,16 @@ export default class EditableMarker {
                                 oldPoint,
                                 oldNextPoint
                             );
-                            segments = TracksRoutingCache.addSegmentToRouting(
-                                currentPoint,
-                                nextPoint,
-                                null, // oldPoint,
-                                nextPolyline,
-                                segments
-                            );
+                            if (nextPolyline) {
+                                nextPoint.geometry = []; // ready for updateLayers
+                                segments = TracksRoutingCache.addSegmentToRouting(
+                                    currentPoint,
+                                    nextPoint,
+                                    null, // oldPoint,
+                                    nextPolyline,
+                                    segments
+                                );
+                            }
                         }
                     }
                 }

--- a/map/src/map/EditableMarker.js
+++ b/map/src/map/EditableMarker.js
@@ -155,6 +155,7 @@ export default class EditableMarker {
                             const newGeo = _.cloneDeep(currentPoint.geometry);
                             newGeo[newGeo.length - 1] = { lat: currentPoint.lat, lng: currentPoint.lng };
                             currentPoint.geometry = newGeo;
+                            track.refreshAnalytics = true;
                         } else {
                             currentPolyline = TrackLayerProvider.updatePolyline(
                                 prevPoint,
@@ -184,6 +185,7 @@ export default class EditableMarker {
                             const newGeo = _.cloneDeep(nextPoint.geometry);
                             newGeo[0] = { lat: currentPoint.lat, lng: currentPoint.lng };
                             nextPoint.geometry = newGeo;
+                            track.refreshAnalytics = true;
                         } else {
                             nextPolyline = TrackLayerProvider.updatePolyline(
                                 currentPoint,

--- a/map/src/map/EditablePolyline.js
+++ b/map/src/map/EditablePolyline.js
@@ -3,7 +3,7 @@ import TrackLayerProvider from './TrackLayerProvider';
 import MarkerOptions from './markers/MarkerOptions';
 import GeometryUtil from 'leaflet-geometryutil';
 import _ from 'lodash';
-import TracksManager, { isPointUnrouted } from '../context/TracksManager';
+import TracksManager, { isPointUnrouted, isProtectedSegment, splitProtectedSegment } from '../context/TracksManager';
 import EditableMarker from './EditableMarker';
 import TracksRoutingCache from '../context/TracksRoutingCache';
 
@@ -133,15 +133,29 @@ export default class EditablePolyline {
         const nextPoint = TrackLayerProvider.getPointByPolyline(currentLayer, points);
         const indexOf = nextPoint ? _.indexOf(points, nextPoint, 0) : -1;
 
+        const findPoint = new L.LatLng(lat, lng);
+
         if (nextPoint && indexOf !== -1) {
-            // 100% found
+            /**
+             * index is 100% found (layer-to-points match)
+             * additionally, find the nearest geometryIndex
+             * it will be used to split GPX-protected segment
+             */
+            let geometryIndex = -1;
+            if (nextPoint.geometry) {
+                const { index } = this.findTheNearestSegment({
+                    point: findPoint,
+                    segments: nextPoint.geometry,
+                });
+                geometryIndex = index;
+            }
             this.dragPoint = {
-                index: indexOf,
                 lat: lat,
                 lng: lng,
+                geometryIndex,
+                index: indexOf,
             };
         } else {
-            const findPoint = new L.LatLng(lat, lng);
             const layerPoints = currentLayer._latlngs;
 
             // process Unrouted Line points: first by the nearest segment, then by points
@@ -176,12 +190,17 @@ export default class EditablePolyline {
         const index = this.dragPoint.index;
 
         const prevPoint = trackPoints[index - 1];
+        const segmentEndPoint = trackPoints[index];
 
         if (isPointUnrouted({ point: trackPoints[index], pointIndex: index, prevPoint })) {
             const newPoint = { lat, lng };
             currentLayer._latlngs.splice(index, 0, newPoint);
             currentLayer.setLatLngs(currentLayer._latlngs);
             trackPoints.splice(index, 0, newPoint);
+        } else if (isProtectedSegment({ startPoint: prevPoint, endPoint: segmentEndPoint })) {
+            const newPoint = { lat, lng };
+            const geometryIndex = this.dragPoint.geometryIndex;
+            splitProtectedSegment({ newPoint, trackPoints, geometryIndex, endPointIndex: index });
         } else {
             const newPoint = _.cloneDeep(track.points[index]);
 

--- a/map/src/map/TrackLayerProvider.js
+++ b/map/src/map/TrackLayerProvider.js
@@ -1,7 +1,7 @@
 import L from 'leaflet';
 import MarkerOptions from './markers/MarkerOptions';
 import _ from 'lodash';
-import TracksManager from '../context/TracksManager';
+import TracksManager, { isProtectedSegment } from '../context/TracksManager';
 import EditablePolyline from './EditablePolyline';
 
 export const TEMP_LAYER_FLAG = 'temp';
@@ -324,12 +324,22 @@ function getPolylines(layers) {
     return res;
 }
 
+// return null on protected segments (null must be processed by parent)
 function updatePolyline(startPoint, endPoint, polylines, oldStartPoint, oldEndPoint) {
     const point2 = oldEndPoint ? oldEndPoint : endPoint;
+
+    if (isProtectedSegment({ startPoint, endPoint: point2 })) {
+        return null;
+    }
 
     let polyline = getPolylineByPoints(point2, polylines);
     if (!polyline) {
         const point1 = oldStartPoint ? oldStartPoint : startPoint;
+
+        if (isProtectedSegment({ startPoint: point1, endPoint: point2 })) {
+            return null;
+        }
+
         polyline = getPolylineByStartEnd(point1, point2, polylines);
     }
     if (!polyline) {

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -439,66 +439,31 @@ export default function LocalClientTrackLayer() {
             return null;
         });
 
-        /**
-         * block was removed because get-analytics requires more data (even for Line-segment)
-         * updateRouteBetweenPoints() will do it better (add ext.extensions, etc)
-         * trackHasRouting() is now checked by the parent
-         */
-        /*
-        // if (trackHasRouting()) {
-        //     newPoint.geometry = Utils.getPointsDist([
-        //         {
-        //             lat: prevPoint.lat,
-        //             lng: prevPoint.lng,
-        //         },
-        //         { lat: newPoint.lat, lng: newPoint.lng },
-        //     ]);
-        //     let polyline = new EditablePolyline(
-        //         map,
-        //         ctx,
-        //         [
-        //             prevPoint,
-        //             {
-        //                 lat: newPoint.lat,
-        //                 lng: newPoint.lng,
-        //             },
-        //         ],
-        //         null,
-        //         ctxTrack
-        //     ).create();
-        //     polyline.setStyle({
-        //         color: geoRouter.getColor(),
-        //     });
-        //     layers.addLayer(polyline);
-        // } else {
-        */
-        {
-            delete newPoint.geometry;
-            if (prevPoint.geometry?.length === 0) {
-                delete prevPoint.geometry;
-            }
-            if (currentPolyline) {
-                currentPolyline._latlngs.push(newPoint);
-                currentPolyline.setLatLngs(currentPolyline._latlngs);
-            } else {
-                let polyline = new EditablePolyline(
-                    map,
-                    ctx,
-                    [
-                        prevPoint,
-                        {
-                            lat: newPoint.lat,
-                            lng: newPoint.lng,
-                        },
-                    ],
-                    null,
-                    ctxTrack
-                ).create();
-                polyline.setStyle({
-                    color: geoRouter.getColor(),
-                });
-                layers.addLayer(polyline);
-            }
+        delete newPoint.geometry;
+        if (prevPoint.geometry?.length === 0) {
+            delete prevPoint.geometry;
+        }
+        if (currentPolyline) {
+            currentPolyline._latlngs.push(newPoint);
+            currentPolyline.setLatLngs(currentPolyline._latlngs);
+        } else {
+            let polyline = new EditablePolyline(
+                map,
+                ctx,
+                [
+                    prevPoint,
+                    {
+                        lat: newPoint.lat,
+                        lng: newPoint.lng,
+                    },
+                ],
+                null,
+                ctxTrack
+            ).create();
+            polyline.setStyle({
+                color: geoRouter.getColor(),
+            });
+            layers.addLayer(polyline);
         }
 
         const analysis = () => {

--- a/map/src/map/layers/LocalClientTrackLayer.js
+++ b/map/src/map/layers/LocalClientTrackLayer.js
@@ -195,7 +195,6 @@ export default function LocalClientTrackLayer() {
             let currLayer = localLayers[track.name];
             if (track.selected && !currLayer) {
                 const needFitBounds = isEmptyTrack(track) === false;
-                console.log('add-1 lt.name', track.name);
                 addTrackToMap(track, needFitBounds, true);
             } else if (currLayer) {
                 currLayer.active = track.selected;

--- a/map/src/store/geoRouter/legacy/updateRouteBetweenPoints.js
+++ b/map/src/store/geoRouter/legacy/updateRouteBetweenPoints.js
@@ -58,7 +58,7 @@ function osrmToPoints(osrm) {
 
 async function updateRouteBetweenPointsOSRM({ start, end, geoProfile, ctx }) {
     const url = this.getURL(geoProfile);
-    const tail = '?geometries=geojson&overview=simplified&steps=false';
+    const tail = '?geometries=geojson&overview=full&steps=false';
 
     const geo = (point) => point.lng.toFixed(6) + ',' + point.lat.toFixed(6); // OSRM lng+lat
     const points = [geo(start), geo(end)];


### PR DESCRIPTION
- [x] open small sized real gpx track, TEST: re-route all segments (should be no actual re-route and no crash), try drag-drop points (first, last, middle), check that charts are refreshed

- [x] add a few Line-profile segments, repeat all tests (should be the same behavior and results)

- [x] add a few non-Line profile segments (a confirmation dialog should appear), try re-route all segments (original gpx segment should have no changes but routed segments should be changed)

- [x] test drag-drop: routed segments, edges between gpx- and routed-segments, try drag new point from gpx-segments, then drag new points from newly generated gpx-segments, etc

- [x] pre-finally, try again re-route all segments (routed should be changed, but **all** gpx-segments should not be re-routed)

- [x] finally, save result (mix of gpx-segments and routed-segments) using the Cloud and then try to Show/Navigate/Plan route (edit) in the App
