### PR TITLE
Add "Close Track", "Save as" buttons to Track Editor

### DIFF
--- a/map/src/dialogs/GlobalConfirmationDialog.jsx
+++ b/map/src/dialogs/GlobalConfirmationDialog.jsx
@@ -34,7 +34,7 @@ export function GlobalConfirmationDialog() {
             {confirmation && (
                 <Dialog open={!!confirmation} onClose={() => setConfirmation(null)}>
                     <DialogContent>{confirmation.text}</DialogContent>
-                    <DialogActions>
+                    <DialogActions sx={{ mb: 1, mr: 1 }}>
                         <Button
                             variant="contained"
                             size="small"

--- a/map/src/dialogs/GlobalConfirmationDialog.jsx
+++ b/map/src/dialogs/GlobalConfirmationDialog.jsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import AppContext from '../context/AppContext';
-import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
+import { Button, Dialog, DialogActions, DialogTitle, DialogContent } from '@mui/material';
 
 /*
     Example:
@@ -15,11 +15,11 @@ import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
     }
 */
 
-export function confirm({ ctx, skip, text, callback }) {
+export function confirm({ ctx, skip, title = null, text, callback }) {
     if (skip) {
         callback();
     } else {
-        ctx.setGlobalConfirmation({ text, callback });
+        ctx.setGlobalConfirmation({ title, text, callback });
     }
     return true;
 }
@@ -33,6 +33,7 @@ export function GlobalConfirmationDialog() {
         <>
             {confirmation && (
                 <Dialog open={!!confirmation} onClose={() => setConfirmation(null)}>
+                    {confirmation.title && <DialogTitle>{confirmation.title}</DialogTitle>}
                     <DialogContent>{confirmation.text}</DialogContent>
                     <DialogActions sx={{ mb: 1, mr: 1 }}>
                         <Button

--- a/map/src/drawer/components/GeneralPanelButtons.jsx
+++ b/map/src/drawer/components/GeneralPanelButtons.jsx
@@ -110,6 +110,7 @@ export default function GeneralPanelButtons({
                                 onClick={() =>
                                     confirm({
                                         ctx,
+                                        title: 'Plan Route: new track',
                                         text: 'Stop editing the current track?',
                                         skip: ctx.createTrack?.enable !== true,
                                         callback: () => TracksManager.createTrack(ctx),

--- a/map/src/infoblock/components/PanelButtons.jsx
+++ b/map/src/infoblock/components/PanelButtons.jsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import TracksManager, { isEmptyTrack } from '../../context/TracksManager';
 import useUndoRedo from '../useUndoRedo';
 import { confirm } from '../../dialogs/GlobalConfirmationDialog';
-import { downloadGpx } from './track/GeneralInfo';
+import { downloadGpx } from './tabs/GeneralInfoTab';
 
 const PanelButtons = ({
     orientation,

--- a/map/src/infoblock/components/PanelButtons.jsx
+++ b/map/src/infoblock/components/PanelButtons.jsx
@@ -130,7 +130,7 @@ const PanelButtons = ({
                                         onClick={() =>
                                             confirm({
                                                 ctx,
-                                                text: 'This is Cloud track. Open Local editor?',
+                                                text: 'Open Cloud track in Local editor?',
                                                 callback: () => TracksManager.handleEditCloudTrack(ctx),
                                             })
                                         }

--- a/map/src/infoblock/components/tabs/GeneralInfoTab.jsx
+++ b/map/src/infoblock/components/tabs/GeneralInfoTab.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { Box, Button, Divider } from '@mui/material';
 import AppContext from '../../../context/AppContext';
-import { Add } from '@mui/icons-material';
+import { Add, Download } from '@mui/icons-material';
 import contextMenuStyles from '../../styles/ContextMenuStyles';
 import DeleteTrackDialog from '../track/dialogs/DeleteTrackDialog';
 import GpxGraphProvider from '../graph/GpxGraphProvider';
@@ -10,6 +10,7 @@ import DescTrackDialog from '../track/dialogs/DescTrackDialog';
 import { isEmptyTrack } from '../../../context/TracksManager';
 import { Checkbox, FormControlLabel } from '@mui/material/';
 import { makeStyles } from '@material-ui/core/styles';
+import TracksManager from '../../../context/TracksManager';
 
 const useStyles = makeStyles({
     checkbox: {
@@ -19,6 +20,21 @@ const useStyles = makeStyles({
         transform: 'scale(0.8)',
     },
 });
+
+export const downloadGpx = async (ctx) => {
+    const gpx = await TracksManager.getGpxTrack(ctx.selectedGpxFile);
+    if (gpx) {
+        const data = gpx.data;
+        const url = document.createElement('a');
+        url.href = URL.createObjectURL(new Blob([data]));
+        const name = TracksManager.prepareName(
+            ctx.selectedGpxFile.name,
+            ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK
+        );
+        url.download = `${name}.gpx`;
+        url.click();
+    }
+};
 
 export default function GeneralInfoTab({ setShowInfoBlock }) {
     const styles = contextMenuStyles();
@@ -82,15 +98,30 @@ export default function GeneralInfoTab({ setShowInfoBlock }) {
                 <Divider sx={{ mt: '3px', mb: '12px' }} />
                 {isEmptyTrack(ctx.selectedGpxFile) === false && (
                     <Button
-                        variant="contained"
                         sx={{ ml: '-0.5px !important' }}
+                        variant="contained"
                         className={styles.button}
-                        onClick={addToCollection}
+                        onClick={() => downloadGpx(ctx)}
                     >
-                        <Add fontSize="small" sx={{ mr: '3px' }} />
-                        Collection
+                        <Download fontSize="small" sx={{ mr: '3px' }} />
+                        Download GPX
                     </Button>
                 )}
+                {isEmptyTrack(ctx.selectedGpxFile) === false && (
+                    <Button variant="contained" className={styles.button} onClick={addToCollection}>
+                        <Add fontSize="small" sx={{ mr: '3px' }} />
+                        Collection (OBF MAP)
+                    </Button>
+                )}
+                <Divider sx={{ mt: 2, mb: 2 }} />
+                <Button
+                    variant="contained"
+                    sx={{ ml: '-0.5px !important' }}
+                    className={styles.button}
+                    onClick={() => setShowInfoBlock(false)}
+                >
+                    Close Editor
+                </Button>
                 <Button
                     variant="contained"
                     sx={{ backgroundColor: '#ff595e !important' }}
@@ -99,7 +130,7 @@ export default function GeneralInfoTab({ setShowInfoBlock }) {
                         setOpenDeleteDialog(true);
                     }}
                 >
-                    Delete
+                    Delete Track
                 </Button>
             </Box>
             {openDeleteDialog && (

--- a/map/src/infoblock/components/tabs/GeneralInfoTab.jsx
+++ b/map/src/infoblock/components/tabs/GeneralInfoTab.jsx
@@ -57,7 +57,7 @@ export default function GeneralInfoTab({ setShowInfoBlock }) {
                 <GeneralInfo width={ctx.infoBlockWidth} setOpenDescDialog={setOpenDescDialog} />
                 {ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK && (
                     <>
-                        <Divider sx={{ mt: '3px', mb: '12px' }} />
+                        {!isEmptyTrack(ctx.selectedGpxFile) && <Divider sx={{ mt: '3px', mb: '12px' }} />}
                         <div style={{ marginLeft: '15px', marginTop: '-10px' }}>
                             {!isEmptyTrack(ctx.selectedGpxFile, false, true) && (
                                 <FormControlLabel
@@ -95,23 +95,23 @@ export default function GeneralInfoTab({ setShowInfoBlock }) {
                         <GpxGraphProvider width={ctx.infoBlockWidth} />
                     </>
                 )}
-                <Divider sx={{ mt: '3px', mb: '12px' }} />
                 {isEmptyTrack(ctx.selectedGpxFile) === false && (
-                    <Button
-                        sx={{ ml: '-0.5px !important' }}
-                        variant="contained"
-                        className={styles.button}
-                        onClick={() => downloadGpx(ctx)}
-                    >
-                        <Download fontSize="small" sx={{ mr: '3px' }} />
-                        Download GPX
-                    </Button>
-                )}
-                {isEmptyTrack(ctx.selectedGpxFile) === false && (
-                    <Button variant="contained" className={styles.button} onClick={addToCollection}>
-                        <Add fontSize="small" sx={{ mr: '3px' }} />
-                        Collection (OBF MAP)
-                    </Button>
+                    <>
+                        <Divider sx={{ mt: '3px', mb: '12px' }} />
+                        <Button
+                            sx={{ ml: '-0.5px !important' }}
+                            variant="contained"
+                            className={styles.button}
+                            onClick={() => downloadGpx(ctx)}
+                        >
+                            <Download fontSize="small" sx={{ mr: '3px' }} />
+                            Download GPX
+                        </Button>
+                        <Button variant="contained" className={styles.button} onClick={addToCollection}>
+                            <Add fontSize="small" sx={{ mr: '3px' }} />
+                            Collection (OBF MAP)
+                        </Button>
+                    </>
                 )}
                 <Divider sx={{ mt: 2, mb: 2 }} />
                 <Button

--- a/map/src/infoblock/components/tabs/GeneralInfoTab.jsx
+++ b/map/src/infoblock/components/tabs/GeneralInfoTab.jsx
@@ -120,7 +120,7 @@ export default function GeneralInfoTab({ setShowInfoBlock }) {
                     className={styles.button}
                     onClick={() => setShowInfoBlock(false)}
                 >
-                    Close Editor
+                    Close Track
                 </Button>
                 <Button
                     variant="contained"

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -23,28 +23,12 @@ import {
     CloudUpload,
     Commit,
     Create,
-    Download,
     Edit,
     ImportExport,
     RouteOutlined,
     Speed,
     Terrain,
 } from '@mui/icons-material';
-
-export const downloadGpx = async (ctx) => {
-    const gpx = await TracksManager.getGpxTrack(ctx.selectedGpxFile);
-    if (gpx) {
-        const data = gpx.data;
-        const url = document.createElement('a');
-        url.href = URL.createObjectURL(new Blob([data]));
-        const name = TracksManager.prepareName(
-            ctx.selectedGpxFile.name,
-            ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK
-        );
-        url.download = `${name}.gpx`;
-        url.click();
-    }
-};
 
 export default function GeneralInfo({ width, setOpenDescDialog }) {
     const styles = contextMenuStyles();
@@ -495,12 +479,6 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                     >
                         <Create fontSize="small" sx={{ mr: '7px' }} />
                         Edit Track
-                    </Button>
-                )}
-                {isEmptyTrack(ctx.selectedGpxFile) === false && (
-                    <Button variant="contained" className={styles.button} onClick={() => downloadGpx(ctx)}>
-                        <Download fontSize="small" sx={{ mr: '3px' }} />
-                        Download GPX
                     </Button>
                 )}
                 {points !== 0 && (

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -450,25 +450,41 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                                   >
                                       • Add description
                                   </Link>
-                                  <Divider sx={{ mt: '6px', mb: '12px' }} light />
                               </>
                           )}
                 </div>
+                <Divider light sx={{ mt: 1, mb: 2 }} />
                 {ctx.loginUser &&
                     ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK &&
                     isEmptyTrack(ctx.selectedGpxFile) === false && (
-                        <Button
-                            variant="contained"
-                            sx={{ ml: '-0.5px !important' }}
-                            className={styles.button}
-                            onClick={() => {
-                                ctx.selectedGpxFile.save = true;
-                                ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
-                            }}
-                        >
-                            <CloudUpload fontSize="small" sx={{ mr: '7px' }} />
-                            Save to cloud
-                        </Button>
+                        <>
+                            <Button
+                                variant="contained"
+                                sx={{ ml: '-0.5px !important' }}
+                                className={styles.button}
+                                onClick={() => {
+                                    ctx.selectedGpxFile.save = true;
+                                    ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
+                                }}
+                            >
+                                <CloudUpload fontSize="small" sx={{ mr: '7px' }} />
+                                Save to Cloud
+                            </Button>
+                            {ctx.createTrack?.cloudAutoSave && (
+                                <Button
+                                    variant="contained"
+                                    className={styles.button}
+                                    onClick={() => {
+                                        ctx.selectedGpxFile.save = true;
+                                        ctx.setSelectedGpxFile({ ...ctx.selectedGpxFile });
+                                        ctx.setCreateTrack({ ...ctx.createTrack, cloudAutoSave: false });
+                                    }}
+                                >
+                                    <CloudUpload fontSize="small" sx={{ mr: '7px' }} />
+                                    Save as
+                                </Button>
+                            )}
+                        </>
                     )}
                 {!ctx.createTrack && ctx.currentObjectType === ctx.OBJECT_TYPE_CLOUD_TRACK && (
                     <Button
@@ -481,6 +497,7 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                         Edit Track
                     </Button>
                 )}
+                <Divider light sx={{ mt: 2, mb: 1 }} />
                 {points !== 0 && (
                     <MenuItem sx={{ ml: -2 }}>
                         <ListItemIcon>

--- a/map/src/infoblock/components/track/GeneralInfo.jsx
+++ b/map/src/infoblock/components/track/GeneralInfo.jsx
@@ -453,11 +453,11 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                               </>
                           )}
                 </div>
-                <Divider light sx={{ mt: 1, mb: 2 }} />
                 {ctx.loginUser &&
                     ctx.currentObjectType === ctx.OBJECT_TYPE_LOCAL_CLIENT_TRACK &&
                     isEmptyTrack(ctx.selectedGpxFile) === false && (
                         <>
+                            <Divider light sx={{ mt: 1, mb: 2 }} />
                             <Button
                                 variant="contained"
                                 sx={{ ml: '-0.5px !important' }}
@@ -484,20 +484,24 @@ export default function GeneralInfo({ width, setOpenDescDialog }) {
                                     Save as
                                 </Button>
                             )}
+                            <Divider light sx={{ mt: 2, mb: 1 }} />
                         </>
                     )}
                 {!ctx.createTrack && ctx.currentObjectType === ctx.OBJECT_TYPE_CLOUD_TRACK && (
-                    <Button
-                        variant="contained"
-                        sx={{ ml: '-0.5px !important' }}
-                        className={styles.button}
-                        onClick={() => TracksManager.handleEditCloudTrack(ctx)}
-                    >
-                        <Create fontSize="small" sx={{ mr: '7px' }} />
-                        Edit Track
-                    </Button>
+                    <>
+                        <Divider light sx={{ mt: 1, mb: 2 }} />
+                        <Button
+                            variant="contained"
+                            sx={{ ml: '-0.5px !important' }}
+                            className={styles.button}
+                            onClick={() => TracksManager.handleEditCloudTrack(ctx)}
+                        >
+                            <Create fontSize="small" sx={{ mr: '7px' }} />
+                            Edit Track
+                        </Button>
+                        <Divider light sx={{ mt: 2, mb: 1 }} />
+                    </>
                 )}
-                <Divider light sx={{ mt: 2, mb: 1 }} />
                 {points !== 0 && (
                     <MenuItem sx={{ ml: -2 }}>
                         <ListItemIcon>


### PR DESCRIPTION
- [x] test: "Download GPX" button moved to the bottom
- [x] test: "Close Track" button added close to "Delete" button
- [x] test: "Save As" button activates when "Edit track" on Cloud Track starts