### PR TITLE
Refactor track list sorting, improve Clear menu for Visible/Local tracks, improve Tooltip for tracks, refactor/speedup Cloud track list rendering

### DIFF
--- a/map/src/context/AppContext.js
+++ b/map/src/context/AppContext.js
@@ -16,24 +16,6 @@ const osmandTileURL = {
     url: 'https://tile.osmand.net/hd/{z}/{x}/{y}.png',
 };
 
-let monthNames = {};
-
-function evaluateMonthNames() {
-    if (Object.keys(monthNames).length > 0) {
-        return monthNames;
-    }
-    for (var i = 0; i < 12; i++) {
-        var objDate = new Date();
-        objDate.setDate(1);
-        objDate.setMonth(i);
-        monthNames[objDate.toLocaleString('en-us', { month: 'short' })] = i + 1;
-        monthNames[
-            objDate.toLocaleString(window.navigator.userLanguage || window.navigator.language, { month: 'short' })
-        ] = i + 1;
-    }
-    return monthNames;
-}
-
 export const toHHMMSS = function (time) {
     var sec_num = time / 1000;
     var hours = Math.floor(sec_num / 3600);
@@ -50,40 +32,6 @@ export const toHHMMSS = function (time) {
         seconds = '0' + Math.round(seconds);
     }
     return hours + ':' + minutes + ':' + seconds;
-};
-
-export const getGpxTime = (f) => {
-    if (f?.details?.analysis?.startTime) {
-        return f.details.analysis.startTime;
-    }
-    let dt = f.name.match(/(20\d\d)-(\d\d)-(\d\d)/);
-    if (!dt) {
-        dt = f.name.match(/(20\d\d)(\d\d)(\d\d)/);
-    }
-    try {
-        if (dt) {
-            let date = new Date();
-            date.setFullYear(parseInt(dt[1]));
-            date.setMonth(parseInt(dt[2]) - 1);
-            date.setDate(parseInt(dt[3]));
-            return date.getTime();
-        } else {
-            dt = f.name.match(/(\d\d) (...) (20\d\d)/);
-            if (dt) {
-                let monthNames = evaluateMonthNames();
-                if (monthNames[dt[2]]) {
-                    let date = new Date();
-                    date.setFullYear(parseInt(dt[3]));
-                    date.setMonth(monthNames[dt[2]] - 1);
-                    date.setDate(parseInt(dt[1]));
-                    return date.getTime();
-                }
-            }
-        }
-    } catch (e) {
-        console.error('getGpxTime', e);
-    }
-    return 0;
 };
 
 async function loadListFiles(loginUser, listFiles, setListFiles, setGpxLoading, gpxFiles, setGpxFiles, setFavorites) {

--- a/map/src/context/AppContext.js
+++ b/map/src/context/AppContext.js
@@ -215,7 +215,7 @@ export const AppContextProvider = (props) => {
     const [loginUser, setLoginUser] = useState('noCheck');
     const [wantDeleteAcc, setWantDeleteAcc] = useState(false);
     const [listFiles, setListFiles] = useState({});
-    const [gpxFiles, setGpxFiles] = useState({});
+    const [gpxFiles, mutateGpxFiles, setGpxFiles] = useMutator({});
     const [searchCtx, setSearchCtx] = useState({});
 
     const [selectedGpxFile, reactSetSelectedGpxFile] = useState({});
@@ -440,6 +440,7 @@ export const AppContextProvider = (props) => {
                 setLoginUser,
                 gpxFiles,
                 setGpxFiles,
+                mutateGpxFiles,
                 gpxLoading,
                 setGpxLoading,
                 selectedGpxFile,

--- a/map/src/context/AppContext.js
+++ b/map/src/context/AppContext.js
@@ -101,14 +101,14 @@ async function loadListFiles(loginUser, listFiles, setListFiles, setGpxLoading, 
                     res.uniqueFiles.forEach((f) => {
                         res.totalUniqueZipSize += f.zipSize;
                     });
-                    res.uniqueFiles = res.uniqueFiles.sort((f, s) => {
-                        let ftime = getGpxTime(f);
-                        let stime = getGpxTime(s);
-                        if (ftime !== stime) {
-                            return ftime > stime ? -1 : 1;
-                        }
-                        return 0;
-                    });
+                    // res.uniqueFiles = res.uniqueFiles.sort((f, s) => {
+                    //     let ftime = getGpxTime(f);
+                    //     let stime = getGpxTime(s);
+                    //     if (ftime !== stime) {
+                    //         return ftime > stime ? -1 : 1;
+                    //     }
+                    //     return 0;
+                    // });
                     setListFiles(res);
                     setGpxLoading(false);
 

--- a/map/src/context/AppContext.js
+++ b/map/src/context/AppContext.js
@@ -49,14 +49,6 @@ async function loadListFiles(loginUser, listFiles, setListFiles, setGpxLoading, 
                     res.uniqueFiles.forEach((f) => {
                         res.totalUniqueZipSize += f.zipSize;
                     });
-                    // res.uniqueFiles = res.uniqueFiles.sort((f, s) => {
-                    //     let ftime = getGpxTime(f);
-                    //     let stime = getGpxTime(s);
-                    //     if (ftime !== stime) {
-                    //         return ftime > stime ? -1 : 1;
-                    //     }
-                    //     return 0;
-                    // });
                     setListFiles(res);
                     setGpxLoading(false);
 

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -629,6 +629,16 @@ function deleteLocalTrack(ctx) {
     }
 }
 
+export function clearAllLocalTracks(ctx) {
+    if (ctx.localTracks.find((t) => t.name === ctx.selectedGpxFile.name)) {
+        ctx.setSelectedGpxFile({});
+    }
+    ctx.setLocalTracks([]);
+    localStorage.removeItem(DATA_SIZE_KEY);
+    localStorage.removeItem(TRACK_VISIBLE_FLAG);
+    deleteLocalTracks(); // delete from localStorage
+}
+
 function formatRouteMode({ profile = 'car', params }) {
     let routeModeStr = profile ?? 'car';
     if (params) {

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -891,10 +891,10 @@ async function getTrackWithAnalysis(path, ctx, setLoading, points) {
 
         // restore previously saved time
         if (data.data && data.data.analysis) {
-            if (saveStartTime) {
+            if (data.data.analysis.startTime === 0 && saveStartTime > 0) {
                 data.data.analysis.startTime = saveStartTime;
             }
-            if (saveEndTime) {
+            if (data.data.analysis.endTime === 0 && saveEndTime > 0) {
                 data.data.analysis.endTime = saveEndTime;
             }
         }

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -1109,13 +1109,13 @@ function evaluateMonthNames() {
 
 export const getGpxTime = (f, reverse = false) => {
     const raw = [];
-    // fill in raw timestamps (unixtime * 1000) (incl. undefined)
-    raw.push(f?.details?.analysis?.startTime); // cloud track
-    raw.push(f?.analysis?.startTime); // local track
-    raw.push(f?.details?.metadata?.time); // gpx
-    raw.push(f?.metaData?.ext?.time); // gpx
-    raw.push(f?.clienttimems); // uploaded
-    // raw.push(f?.updatetimems); // skip
+    // fill in raw timestamps (unixtime * 1000), including undefined values
+    raw.push(f?.details?.analysis?.startTime); // cloud - stored analysis
+    raw.push(f?.analysis?.startTime); // local track - fresh analysis
+    raw.push(f?.details?.metadata?.time); // gpx - meta (cloud track)
+    raw.push(f?.metaData?.ext?.time); // gpx - meta (local track)
+    raw.push(f?.clienttimems); // uploaded (cloud timestamp?)
+    raw.push(f?.updatetimems); // updated (cloud timestamp?)
 
     // validate raw to avoid using illegal values
     const minAllowed = new Date(2002, 1, 1).getTime(); // GPX was initiated

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -864,7 +864,12 @@ async function getTrackWithAnalysis(path, ctx, setLoading, points) {
         analysis: ctx.selectedGpxFile.analysis,
     };
 
+    // time vs better cache
+    let saveStartTime = null;
+    let saveEndTime = null;
     if (postData.analysis) {
+        saveStartTime = postData.analysis.startTime;
+        saveEndTime = postData.analysis.endTime;
         // zero every-time-unique variables for better caching
         postData.analysis.startTime = postData.analysis.endTime = 0;
     }
@@ -883,6 +888,16 @@ async function getTrackWithAnalysis(path, ctx, setLoading, points) {
         const data = FavoritesManager.prepareTrackData(_.cloneDeep(resp.data));
 
         const newGpxFile = { ...ctx.selectedGpxFile }; // don't modify state
+
+        // restore previously saved time
+        if (data.data && data.data.analysis) {
+            if (saveStartTime) {
+                data.data.analysis.startTime = saveStartTime;
+            }
+            if (saveEndTime) {
+                data.data.analysis.endTime = saveEndTime;
+            }
+        }
 
         Object.keys(data.data).forEach((t) => {
             newGpxFile[`${t}`] = data.data[t];

--- a/map/src/context/TracksManager.js
+++ b/map/src/context/TracksManager.js
@@ -546,6 +546,20 @@ async function saveTrack(ctx, currentFolder, fileName, type, file) {
                     if (resJson && resJson.uniqueFiles) {
                         ctx.setListFiles(resJson);
                     }
+                } else {
+                    // refresh updatetimems locally to resort track list
+                    // real data will be refreshed after list-files reloaded
+                    ctx.setTracksGroups((o) => {
+                        o.forEach((g) => {
+                            g.files.forEach((f) => {
+                                if (f.name === params.name) {
+                                    f.updatetimems = Date.now();
+                                }
+                            });
+                            g.files = [...g.files]; // useMemo deep dep (group.files) in CloudTrackGroup
+                        });
+                        return [...o];
+                    });
                 }
 
                 return true;

--- a/map/src/drawer/components/OsmAndMapFrame.js
+++ b/map/src/drawer/components/OsmAndMapFrame.js
@@ -145,11 +145,10 @@ const OsmAndMapFrame = () => {
             )}
             {
                 <Drawer
-                    variant="temporary"
+                    variant="persistent"
                     open={mainMenuOpen}
                     onClose={toggleMainMenu}
                     hideBackdrop={!mobile}
-                    disableEnforceFocus
                     PaperProps={{
                         sx: {
                             boxSizing: 'border-box',

--- a/map/src/drawer/components/VisibleGroup.jsx
+++ b/map/src/drawer/components/VisibleGroup.jsx
@@ -178,7 +178,7 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     {visibleTracks.local.length > 0 &&
                         visibleTracks.local
-                            .sort((a, b) => a.name > b.name)
+                            .sort((a, b) => (a.name > b.name) - (a.name < b.name))
                             .map((track, index) => {
                                 return (
                                     <LocalTrackItem className={classes.item} key={'vis-local-' + index} track={track} />
@@ -186,7 +186,7 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
                             })}
                     {visibleTracks.cloud.length > 0 &&
                         visibleTracks.cloud
-                            .sort((a, b) => a.name > b.name)
+                            .sort((a, b) => (a.name > b.name) - (a.name < b.name))
                             .map((track, index) => {
                                 return (
                                     <CloudTrackItem

--- a/map/src/drawer/components/VisibleGroup.jsx
+++ b/map/src/drawer/components/VisibleGroup.jsx
@@ -174,7 +174,7 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
                 </Box>
                 {visibleTracksOpen ? <ExpandLess /> : <ExpandMore />}
             </MenuItem>
-            <Collapse in={visibleTracksOpen} timeout="auto" unmountOnExit>
+            <Collapse in={visibleTracksOpen} timeout="auto">
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     {visibleTracks.local.length > 0 &&
                         visibleTracks.local

--- a/map/src/drawer/components/VisibleGroup.jsx
+++ b/map/src/drawer/components/VisibleGroup.jsx
@@ -1,6 +1,6 @@
 import { Box, Button, Collapse, ListItemIcon, ListItemText, MenuItem, Typography } from '@mui/material';
 import { ExpandLess, ExpandMore, Visibility } from '@mui/icons-material';
-import React, { useContext, useEffect, useState } from 'react';
+import { useRef, useContext, useEffect, useState, useMemo } from 'react';
 import CloudTrackItem from './tracks/CloudTrackItem';
 import { makeStyles } from '@material-ui/core/styles';
 import LocalTrackItem from './tracks/LocalTrackItem';
@@ -24,7 +24,7 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
 
     const classes = useStyles();
     const [visibleTracksOpen, setVisibleTracksOpen] = useState(false);
-    const anchorEl = React.useRef(null);
+    const anchorEl = useRef(null);
     const [open, setOpen] = useState(false);
 
     const handleToggle = () => {
@@ -149,6 +149,35 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
         );
     }, [visibleTracks]);
 
+    const localItems = useMemo(
+        () =>
+            visibleTracks.local.length > 0 &&
+            visibleTracks.local
+                .sort((a, b) => (a.name > b.name) - (a.name < b.name))
+                .map((track, index) => {
+                    return <LocalTrackItem className={classes.item} key={'vis-local-' + index} track={track} />;
+                }),
+        [visibleTracks.local, visibleTracks.local.length]
+    );
+
+    const cloudItems = useMemo(
+        () =>
+            visibleTracks.cloud.length > 0 &&
+            visibleTracks.cloud
+                .sort((a, b) => (a.name > b.name) - (a.name < b.name))
+                .map((track, index) => {
+                    return (
+                        <CloudTrackItem
+                            key={'vis-cloud-' + index}
+                            className={classes.item}
+                            customIcon={<CloudOutlinedIcon fontSize="small" sx={{ mb: '-3px', mr: 1 }} />}
+                            file={track}
+                        />
+                    );
+                }),
+        [visibleTracks.cloud, visibleTracks.cloud.length]
+    );
+
     return (
         <div>
             <MenuItem sx={{ ml: 3 }} className={classes.group} onClick={() => setVisibleTracksOpen(!visibleTracksOpen)}>
@@ -176,27 +205,8 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
             </MenuItem>
             <Collapse in={visibleTracksOpen} timeout="auto">
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
-                    {visibleTracks.local.length > 0 &&
-                        visibleTracks.local
-                            .sort((a, b) => (a.name > b.name) - (a.name < b.name))
-                            .map((track, index) => {
-                                return (
-                                    <LocalTrackItem className={classes.item} key={'vis-local-' + index} track={track} />
-                                );
-                            })}
-                    {visibleTracks.cloud.length > 0 &&
-                        visibleTracks.cloud
-                            .sort((a, b) => (a.name > b.name) - (a.name < b.name))
-                            .map((track, index) => {
-                                return (
-                                    <CloudTrackItem
-                                        key={'vis-cloud-' + index}
-                                        className={classes.item}
-                                        customIcon={<CloudOutlinedIcon fontSize="small" sx={{ mb: '-3px', mr: 1 }} />}
-                                        file={track}
-                                    />
-                                );
-                            })}
+                    {localItems}
+                    {cloudItems}
                 </div>
             </Collapse>
         </div>

--- a/map/src/drawer/components/VisibleGroup.jsx
+++ b/map/src/drawer/components/VisibleGroup.jsx
@@ -150,20 +150,26 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
             <Collapse in={visibleTracksOpen} timeout="auto" unmountOnExit>
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     {visibleTracks.local.length > 0 &&
-                        visibleTracks.local.map((track, index) => {
-                            return <LocalTrackItem className={classes.item} key={'vis-local-' + index} track={track} />;
-                        })}
+                        visibleTracks.local
+                            .sort((a, b) => a.name > b.name)
+                            .map((track, index) => {
+                                return (
+                                    <LocalTrackItem className={classes.item} key={'vis-local-' + index} track={track} />
+                                );
+                            })}
                     {visibleTracks.cloud.length > 0 &&
-                        visibleTracks.cloud.map((track, index) => {
-                            return (
-                                <CloudTrackItem
-                                    key={'vis-cloud-' + index}
-                                    className={classes.item}
-                                    customIcon={<CloudOutlinedIcon fontSize="small" sx={{ mb: '-3px', mr: 1 }} />}
-                                    file={track}
-                                />
-                            );
-                        })}
+                        visibleTracks.cloud
+                            .sort((a, b) => a.name > b.name)
+                            .map((track, index) => {
+                                return (
+                                    <CloudTrackItem
+                                        key={'vis-cloud-' + index}
+                                        className={classes.item}
+                                        customIcon={<CloudOutlinedIcon fontSize="small" sx={{ mb: '-3px', mr: 1 }} />}
+                                        file={track}
+                                    />
+                                );
+                            })}
                 </div>
             </Collapse>
         </div>

--- a/map/src/drawer/components/VisibleGroup.jsx
+++ b/map/src/drawer/components/VisibleGroup.jsx
@@ -85,11 +85,38 @@ export default function VisibleGroup({ visibleTracks, setVisibleTracks }) {
     }
 
     function clear() {
-        let empty = {
+        // clear Visible Local Tracks
+        if (visibleTracks.local.length > 0) {
+            visibleTracks.local.forEach((file) =>
+                ctx.localTracks.forEach((track) => {
+                    if (track.name === file.name) {
+                        track.selected = false; // unselect
+                    }
+                })
+            );
+            ctx.setLocalTracks([...ctx.localTracks]);
+        }
+
+        // clear Visible Cloud Tracks
+        // close currently open Cloud track
+        if (visibleTracks.cloud.length > 0) {
+            visibleTracks.cloud.forEach((file) => {
+                if (ctx.selectedGpxFile.name === file.name) {
+                    ctx.setCurrentObjectType(null);
+                    ctx.setSelectedGpxFile({});
+                }
+            });
+            visibleTracks.cloud.forEach((file) => (ctx.gpxFiles[file.name].url = null)); // unselect
+            ctx.setGpxFiles({ ...ctx.gpxFiles });
+        }
+
+        const empty = {
             local: [],
             cloud: [],
         };
         setVisibleTracks({ ...empty });
+
+        localStorage.removeItem(TracksManager.TRACK_VISIBLE_FLAG); // clear saved list finally
     }
 
     useEffect(() => {

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -67,7 +67,7 @@ export default function Actions({ files, setSortFiles }) {
 
     useEffect(() => {
         setSortFiles(currentMethod.callback(files, currentMethod.reverse));
-    }, [files, currentMethod]);
+    }, [files, currentMethod]); // ensure that files[] is modified for Object.is() check
 
     function select(method) {
         const isCurrent = method.alt === currentMethod.alt;

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -1,52 +1,128 @@
-import { IconButton } from '@mui/material';
-import { getGpxTime } from '../../../context/AppContext';
-import { Sort, SortByAlpha } from '@mui/icons-material';
-import React, { useState } from 'react';
+import { Box, IconButton } from '@mui/material';
+// import { getGpxTime } from '../../../context/AppContext';
+import { SortByAlpha, Update, History, CallMade, CallReceived } from '@mui/icons-material';
+import { useState, useEffect } from 'react';
+
+function byAlpha(files, reverse) {
+    console.log('alpha', reverse);
+    return files;
+}
+
+function byTime(files, reverse) {
+    console.log('time', reverse);
+    return files;
+}
+
+function byDistance(files, reverse) {
+    console.log('distance', reverse);
+    return files;
+}
+
+const allMethods = {
+    alpha: {
+        default: true,
+        reverse: false,
+        callback: byAlpha,
+        directIcon: <SortByAlpha fontSize="small" />,
+        reverseIcon: <SortByAlpha fontSize="small" sx={{ transform: 'scaleX(-1) scaleY(-1)' }} />,
+        alt: 'Sort alphabetically',
+    },
+    time: {
+        reverse: true,
+        callback: byTime,
+        directIcon: <Update fontSize="small" />,
+        reverseIcon: <History fontSize="small" />,
+        alt: 'Sort by time',
+    },
+    distance: {
+        reverse: true,
+        callback: byDistance,
+        directIcon: <CallMade fontSize="small" />,
+        reverseIcon: <CallReceived fontSize="small" />,
+        alt: 'Sort by distance',
+    },
+};
+
+const defaultMethod = () => {
+    for (let l in allMethods) {
+        if (allMethods[l].default) {
+            return allMethods[l];
+        }
+    }
+    return allMethods[Object.keys(allMethods)[0]];
+};
 
 export default function Actions({ files, setSortFiles }) {
-    const [alphaUp, setAlphaUp] = useState(false);
-    const [timeUp, setTimeUp] = useState(true);
+    const [currentMethod, setCurrentMethod] = useState(defaultMethod);
 
-    return (
-        <div>
-            <IconButton
-                sx={{ ml: 4 }}
-                onClick={(e) => {
-                    e.stopPropagation();
-                    const sortedCopy = [...files].sort((f, s) => {
-                        let ftime = getGpxTime(f);
-                        let stime = getGpxTime(s);
-                        if (ftime === stime) {
-                            return f.name > s.name ? 1 : -1;
-                        }
-                        if (timeUp) {
-                            return ftime > stime ? 1 : -1;
-                        } else {
-                            return ftime < stime ? 1 : -1;
-                        }
-                    });
-                    setTimeUp(!timeUp);
-                    setSortFiles(sortedCopy);
-                }}
-            >
-                <Sort fontSize="small" />
+    useEffect(() => {
+        console.log('refresh', files);
+        setSortFiles(currentMethod.callback(files, currentMethod.reverse));
+    }, [files, currentMethod]);
+
+    function select(method) {
+        const isCurrent = method.alt === currentMethod.alt;
+        console.log('current', isCurrent);
+        setCurrentMethod({ ...method, reverse: isCurrent ? !currentMethod.reverse : method.reverse });
+    }
+
+    const icons = [];
+
+    for (let m in allMethods) {
+        const method = allMethods[m];
+        const isCurrent = method.alt === currentMethod.alt;
+        const reverse = isCurrent ? currentMethod.reverse : method.reverse;
+        const icon = reverse ? method.reverseIcon : method.directIcon;
+        const color = isCurrent ? 'primary' : '';
+        icons.push(
+            <IconButton key={m} color={color} onClick={() => select(method)}>
+                {icon}
             </IconButton>
-            <IconButton
-                onClick={(e) => {
-                    e.stopPropagation();
-                    const sortedCopy = [...files].sort((f, s) => {
-                        if (alphaUp) {
-                            return f.name > s.name ? 1 : -1;
-                        } else {
-                            return f.name < s.name ? 1 : -1;
-                        }
-                    });
-                    setAlphaUp(!alphaUp);
-                    setSortFiles(sortedCopy);
-                }}
-            >
-                <SortByAlpha fontSize="small" />
-            </IconButton>
-        </div>
-    );
+        );
+    }
+
+    return <Box sx={{ ml: 4 }}>{icons}</Box>;
+
+    // return (
+    //     <div>
+    //         <IconButton
+    //             sx={{ ml: 4 }}
+    //             onClick={(e) => {
+    //                 e.stopPropagation();
+    //                 const sortedCopy = [...files].sort((f, s) => {
+    //                     let ftime = getGpxTime(f);
+    //                     let stime = getGpxTime(s);
+    //                     if (ftime === stime) {
+    //                         return f.name > s.name ? 1 : -1;
+    //                     }
+    //                     if (timeUp) {
+    //                         return ftime > stime ? 1 : -1;
+    //                     } else {
+    //                         return ftime < stime ? 1 : -1;
+    //                     }
+    //                 });
+    //                 setTimeUp(!timeUp);
+    //                 setSortFiles(sortedCopy);
+    //             }}
+    //         >
+    //             <Sort fontSize="small" />
+    //         </IconButton>
+    //         <IconButton
+    //             onClick={(e) => {
+    //                 e.stopPropagation();
+    //                 const sortedCopy = [...files].sort((f, s) => {
+    //                     if (alphaUp) {
+    //                         return f.name > s.name ? 1 : -1;
+    //                     } else {
+    //                         return f.name < s.name ? 1 : -1;
+    //                     }
+    //                 });
+    //                 setAlphaUp(!alphaUp);
+    //                 setSortFiles(sortedCopy);
+    //             }}
+    //         >
+    //             <SortByAlpha fontSize="small" />
+    //         </IconButton>
+    //     </div>
+    // );
 }

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -16,8 +16,8 @@ function byAlpha(files, reverse) {
 
 function byTime(files, reverse) {
     const sortedCopy = [...files].sort((a, b) => {
-        const A = getGpxTime(a);
-        const B = getGpxTime(b);
+        const A = getGpxTime(a, reverse);
+        const B = getGpxTime(b, reverse);
         if (A === B) {
             return az(a.name, b.name);
         }

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -4,12 +4,10 @@ import { SortByAlpha, Update, History, CallMade, CallReceived } from '@mui/icons
 import { useState, useEffect } from 'react';
 
 function byAlpha(files, reverse) {
-    const sortedCopy = [...files].sort((f, s) => {
-        if (reverse) {
-            return f.name < s.name ? 1 : -1;
-        } else {
-            return f.name > s.name ? 1 : -1;
-        }
+    const sortedCopy = [...files].sort((a, b) => {
+        const A = a.name;
+        const B = b.name;
+        return reverse ? (B > A) - (B < A) : (A > B) - (A < B);
     });
     return sortedCopy;
 }

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -20,8 +20,12 @@ function byTime(files, reverse) {
 }
 
 function byDistance(files, reverse) {
-    console.log('distance', reverse);
-    return files;
+    const sortedCopy = [...files].sort((a, b) => {
+        const A = a.analysis?.totalDistance ?? a.details?.analysis?.totalDistance ?? 0;
+        const B = b.analysis?.totalDistance ?? b.details?.analysis?.totalDistance ?? 0;
+        return reverse ? B - A : A - B;
+    });
+    return sortedCopy;
 }
 
 const allMethods = {

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -1,7 +1,9 @@
 import { Box, IconButton, Tooltip } from '@mui/material';
-// import { getGpxTime } from '../../../context/AppContext';
+import { getGpxTime } from '../../../context/TracksManager';
 import { SortByAlpha, Update, History, CallMade, CallReceived } from '@mui/icons-material';
 import { useState, useEffect } from 'react';
+
+const az = (a, b) => (a > b) - (a < b);
 
 function byAlpha(files, reverse) {
     const sortedCopy = [...files].sort((a, b) => {
@@ -13,14 +15,24 @@ function byAlpha(files, reverse) {
 }
 
 function byTime(files, reverse) {
-    console.log('time', reverse);
-    return files;
+    const sortedCopy = [...files].sort((a, b) => {
+        const A = getGpxTime(a);
+        const B = getGpxTime(b);
+        if (A === B) {
+            return az(a.name, b.name);
+        }
+        return reverse ? B - A : A - B;
+    });
+    return sortedCopy;
 }
 
 function byDistance(files, reverse) {
     const sortedCopy = [...files].sort((a, b) => {
         const A = a.analysis?.totalDistance ?? a.details?.analysis?.totalDistance ?? 0;
         const B = b.analysis?.totalDistance ?? b.details?.analysis?.totalDistance ?? 0;
+        if (A === B) {
+            return az(a.name, b.name);
+        }
         return reverse ? B - A : A - B;
     });
     return sortedCopy;
@@ -92,47 +104,4 @@ export default function Actions({ files, setSortFiles }) {
     }
 
     return <Box sx={{ ml: 4 }}>{icons}</Box>;
-
-    // return (
-    //     <div>
-    //         <IconButton
-    //             sx={{ ml: 4 }}
-    //             onClick={(e) => {
-    //                 e.stopPropagation();
-    //                 const sortedCopy = [...files].sort((f, s) => {
-    //                     let ftime = getGpxTime(f);
-    //                     let stime = getGpxTime(s);
-    //                     if (ftime === stime) {
-    //                         return f.name > s.name ? 1 : -1;
-    //                     }
-    //                     if (timeUp) {
-    //                         return ftime > stime ? 1 : -1;
-    //                     } else {
-    //                         return ftime < stime ? 1 : -1;
-    //                     }
-    //                 });
-    //                 setTimeUp(!timeUp);
-    //                 setSortFiles(sortedCopy);
-    //             }}
-    //         >
-    //             <Sort fontSize="small" />
-    //         </IconButton>
-    //         <IconButton
-    //             onClick={(e) => {
-    //                 e.stopPropagation();
-    //                 const sortedCopy = [...files].sort((f, s) => {
-    //                     if (alphaUp) {
-    //                         return f.name > s.name ? 1 : -1;
-    //                     } else {
-    //                         return f.name < s.name ? 1 : -1;
-    //                     }
-    //                 });
-    //                 setAlphaUp(!alphaUp);
-    //                 setSortFiles(sortedCopy);
-    //             }}
-    //         >
-    //             <SortByAlpha fontSize="small" />
-    //         </IconButton>
-    //     </div>
-    // );
 }

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -72,17 +72,19 @@ export default function Actions({ files, setSortFiles }) {
 
     const icons = [];
 
-    for (let m in allMethods) {
-        const method = allMethods[m];
-        const isCurrent = method.alt === currentMethod.alt;
-        const reverse = isCurrent ? currentMethod.reverse : method.reverse;
-        const icon = reverse ? method.reverseIcon : method.directIcon;
-        const color = isCurrent ? 'primary' : '';
-        icons.push(
-            <IconButton key={m} color={color} onClick={() => select(method)}>
-                {icon}
-            </IconButton>
-        );
+    if (files && files.length > 1) {
+        for (let m in allMethods) {
+            const method = allMethods[m];
+            const isCurrent = method.alt === currentMethod.alt;
+            const reverse = isCurrent ? currentMethod.reverse : method.reverse;
+            const icon = reverse ? method.reverseIcon : method.directIcon;
+            const color = isCurrent ? 'primary' : '';
+            icons.push(
+                <IconButton key={m} color={color} onClick={() => select(method)}>
+                    {icon}
+                </IconButton>
+            );
+        }
     }
 
     return <Box sx={{ ml: 4 }}>{icons}</Box>;

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -4,8 +4,14 @@ import { SortByAlpha, Update, History, CallMade, CallReceived } from '@mui/icons
 import { useState, useEffect } from 'react';
 
 function byAlpha(files, reverse) {
-    console.log('alpha', reverse);
-    return files;
+    const sortedCopy = [...files].sort((f, s) => {
+        if (reverse) {
+            return f.name < s.name ? 1 : -1;
+        } else {
+            return f.name > s.name ? 1 : -1;
+        }
+    });
+    return sortedCopy;
 }
 
 function byTime(files, reverse) {
@@ -56,13 +62,11 @@ export default function Actions({ files, setSortFiles }) {
     const [currentMethod, setCurrentMethod] = useState(defaultMethod);
 
     useEffect(() => {
-        console.log('refresh', files);
         setSortFiles(currentMethod.callback(files, currentMethod.reverse));
     }, [files, currentMethod]);
 
     function select(method) {
         const isCurrent = method.alt === currentMethod.alt;
-        console.log('current', isCurrent);
         setCurrentMethod({ ...method, reverse: isCurrent ? !currentMethod.reverse : method.reverse });
     }
 

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -1,4 +1,4 @@
-import { Box, IconButton } from '@mui/material';
+import { Box, IconButton, Tooltip } from '@mui/material';
 // import { getGpxTime } from '../../../context/AppContext';
 import { SortByAlpha, Update, History, CallMade, CallReceived } from '@mui/icons-material';
 import { useState, useEffect } from 'react';
@@ -84,9 +84,11 @@ export default function Actions({ files, setSortFiles }) {
             const icon = reverse ? method.reverseIcon : method.directIcon;
             const color = isCurrent ? 'primary' : '';
             icons.push(
-                <IconButton key={m} color={color} onClick={() => select(method)}>
-                    {icon}
-                </IconButton>
+                <Tooltip key={m} title={method.alt} placement="top" arrow>
+                    <IconButton color={color} onClick={() => select(method)}>
+                        {icon}
+                    </IconButton>
+                </Tooltip>
             );
         }
     }

--- a/map/src/drawer/components/tracks/Actions.jsx
+++ b/map/src/drawer/components/tracks/Actions.jsx
@@ -40,7 +40,6 @@ function byDistance(files, reverse) {
 
 const allMethods = {
     alpha: {
-        default: true,
         reverse: false,
         callback: byAlpha,
         directIcon: <SortByAlpha fontSize="small" />,
@@ -48,6 +47,7 @@ const allMethods = {
         alt: 'Sort alphabetically',
     },
     time: {
+        default: true,
         reverse: true,
         callback: byTime,
         directIcon: <Update fontSize="small" />,

--- a/map/src/drawer/components/tracks/CloudTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackGroup.jsx
@@ -1,7 +1,7 @@
 import { Box, Button, Collapse, ListItemIcon, ListItemText, MenuItem, Typography } from '@mui/material';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
-import React, { useContext, useEffect, useState } from 'react';
+import { useRef, useContext, useEffect, useState, useMemo } from 'react';
 import CloudTrackItem from './CloudTrackItem';
 
 import Actions from './Actions';
@@ -17,7 +17,7 @@ export default function CloudTrackGroup({ index, group }) {
     const [tracksOpen, setTracksOpen] = useState(false);
     const [showTracks, setShowTracks] = useState([]);
     const [sortFiles, setSortFiles] = useState([]);
-    const anchorEl = React.useRef(null);
+    const anchorEl = useRef(null);
     const [open, setOpen] = useState(false);
 
     const handleToggle = () => {
@@ -65,6 +65,14 @@ export default function CloudTrackGroup({ index, group }) {
         );
     };
 
+    const trackItems = useMemo(() => {
+        const items = [];
+        (sortFiles.length > 0 ? sortFiles : group.files).map((file) => {
+            items.push(<CloudTrackItem key={'cloudtrack-' + file.name} file={file} />);
+        });
+        return items;
+    }, [sortFiles, group.files, group.files.length]);
+
     return (
         <div className={styles.drawerItem} key={'group' + group.name + index}>
             <MenuItem
@@ -107,9 +115,7 @@ export default function CloudTrackGroup({ index, group }) {
             <Collapse in={showTracks.includes(index)} timeout="auto">
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     <Actions files={group.files} setSortFiles={setSortFiles} />
-                    {(sortFiles.length > 0 ? sortFiles : group.files).map((file) => {
-                        return <CloudTrackItem key={'cloudtrack-' + file.name} file={file} />;
-                    })}
+                    {trackItems}
                 </div>
             </Collapse>
         </div>

--- a/map/src/drawer/components/tracks/CloudTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackGroup.jsx
@@ -66,7 +66,7 @@ export default function CloudTrackGroup({ index, group }) {
     };
 
     return (
-        <div className={styles.drawerItem} key={'group' + index}>
+        <div className={styles.drawerItem} key={'group' + group.name + index}>
             <MenuItem
                 sx={{ ml: 3 }}
                 divider

--- a/map/src/drawer/components/tracks/CloudTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackGroup.jsx
@@ -107,8 +107,8 @@ export default function CloudTrackGroup({ index, group }) {
             <Collapse in={showTracks.includes(index)} timeout="auto">
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     <Actions files={group.files} setSortFiles={setSortFiles} />
-                    {(sortFiles.length > 0 ? sortFiles : group.files).map((file, index) => {
-                        return <CloudTrackItem key={'cloudtrack-' + index} file={file} />;
+                    {(sortFiles.length > 0 ? sortFiles : group.files).map((file) => {
+                        return <CloudTrackItem key={'cloudtrack-' + file.name} file={file} />;
                     })}
                 </div>
             </Collapse>

--- a/map/src/drawer/components/tracks/CloudTrackItem.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackItem.jsx
@@ -5,9 +5,12 @@ import Utils from '../../../util/Utils';
 import TrackInfo from './TrackInfo';
 import TracksManager, { isEmptyTrack } from '../../../context/TracksManager';
 import _ from 'lodash';
+import { useWindowSize } from '../../../util/hooks/useWindowSize';
 
 export default function CloudTrackItem({ file, customIcon = null }) {
     const ctx = useContext(AppContext);
+
+    const [, , mobile] = useWindowSize();
 
     const [loadingTrack, setLoadingTrack] = useState(false);
     const [error, setError] = useState(false);
@@ -83,24 +86,24 @@ export default function CloudTrackItem({ file, customIcon = null }) {
 
     return (
         <>
-            <MenuItem key={file.name} onClick={() => addTrackToMap(ctx.setGpxLoading)}>
-                <Tooltip title={<TrackInfo file={file} />}>
+            <Tooltip title={<TrackInfo file={file} />} arrow placement={mobile ? 'bottom' : 'right'}>
+                <MenuItem key={file.name} onClick={() => addTrackToMap(ctx.setGpxLoading)}>
                     <ListItemText inset>
                         <Typography variant="inherit" noWrap>
                             {customIcon}
                             {TracksManager.getFileName(file)}
                         </Typography>
                     </ListItemText>
-                </Tooltip>
-                <Switch
-                    disabled={loadingTrack}
-                    checked={!!ctx.gpxFiles[file.name]?.url}
-                    onClick={(e) => e.stopPropagation()}
-                    onChange={(e) => {
-                        !file.local && enableLayer(setLoadingTrack, e.target.checked);
-                    }}
-                />
-            </MenuItem>
+                    <Switch
+                        disabled={loadingTrack}
+                        checked={!!ctx.gpxFiles[file.name]?.url}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={(e) => {
+                            !file.local && enableLayer(setLoadingTrack, e.target.checked);
+                        }}
+                    />
+                </MenuItem>
+            </Tooltip>
             {loadingTrack ? <LinearProgress /> : <></>}
             {error && (
                 <Alert

--- a/map/src/drawer/components/tracks/CloudTrackItem.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackItem.jsx
@@ -86,37 +86,37 @@ export default function CloudTrackItem({ file, customIcon = null }) {
         }
     }
 
-    return (
-        <>
-            <Tooltip title={info} arrow placement={mobile ? 'bottom' : 'right'}>
-                <MenuItem key={file.name} onClick={() => addTrackToMap(ctx.setGpxLoading)}>
-                    <ListItemText inset>
-                        <Typography variant="inherit" noWrap>
-                            {customIcon}
-                            {TracksManager.getFileName(file)}
-                        </Typography>
-                    </ListItemText>
-                    <Switch
-                        disabled={loadingTrack}
-                        checked={!!ctx.gpxFiles[file.name]?.url}
-                        onClick={(e) => e.stopPropagation()}
-                        onChange={(e) => {
-                            !file.local && enableLayer(setLoadingTrack, e.target.checked);
-                        }}
-                    />
-                </MenuItem>
-            </Tooltip>
-            {loadingTrack ? <LinearProgress /> : <></>}
-            {error && (
-                <Alert
-                    onClose={() => {
-                        setError(false);
-                    }}
-                    severity="warning"
-                >
-                    Something went wrong!
-                </Alert>
-            )}
-        </>
+    const rendered = useMemo(
+        () => (
+            <>
+                <Tooltip title={info} arrow placement={mobile ? 'bottom' : 'right'}>
+                    <MenuItem onClick={() => addTrackToMap(ctx.setGpxLoading)}>
+                        <ListItemText inset>
+                            <Typography variant="inherit" noWrap>
+                                {customIcon}
+                                {TracksManager.getFileName(file)}
+                            </Typography>
+                        </ListItemText>
+                        <Switch
+                            disabled={loadingTrack}
+                            checked={!!ctx.gpxFiles[file.name]?.url}
+                            onClick={(e) => e.stopPropagation()}
+                            onChange={(e) => {
+                                !file.local && enableLayer(setLoadingTrack, e.target.checked);
+                            }}
+                        />
+                    </MenuItem>
+                </Tooltip>
+                {loadingTrack ? <LinearProgress /> : <></>}
+                {error && (
+                    <Alert onClose={() => setError(false)} severity="warning">
+                        Something went wrong!
+                    </Alert>
+                )}
+            </>
+        ),
+        [info, mobile, customIcon, file, loadingTrack, ctx.gpxFiles[file.name]?.url, error]
     );
+
+    return rendered;
 }

--- a/map/src/drawer/components/tracks/CloudTrackItem.jsx
+++ b/map/src/drawer/components/tracks/CloudTrackItem.jsx
@@ -1,6 +1,6 @@
 import AppContext from '../../../context/AppContext';
 import { Alert, LinearProgress, ListItemText, MenuItem, Switch, Tooltip, Typography } from '@mui/material';
-import React, { useContext, useState } from 'react';
+import { useContext, useState, useMemo } from 'react';
 import Utils from '../../../util/Utils';
 import TrackInfo from './TrackInfo';
 import TracksManager, { isEmptyTrack } from '../../../context/TracksManager';
@@ -14,6 +14,8 @@ export default function CloudTrackItem({ file, customIcon = null }) {
 
     const [loadingTrack, setLoadingTrack] = useState(false);
     const [error, setError] = useState(false);
+
+    const info = useMemo(() => <TrackInfo file={file} />, [file]);
 
     async function enableLayer(setProgressVisible, visible) {
         if (!visible) {
@@ -86,7 +88,7 @@ export default function CloudTrackItem({ file, customIcon = null }) {
 
     return (
         <>
-            <Tooltip title={<TrackInfo file={file} />} arrow placement={mobile ? 'bottom' : 'right'}>
+            <Tooltip title={info} arrow placement={mobile ? 'bottom' : 'right'}>
                 <MenuItem key={file.name} onClick={() => addTrackToMap(ctx.setGpxLoading)}>
                     <ListItemText inset>
                         <Typography variant="inherit" noWrap>

--- a/map/src/drawer/components/tracks/LocalTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackGroup.jsx
@@ -120,13 +120,13 @@ export default function LocalTrackGroup() {
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     <Actions files={ctx.localTracks} setSortFiles={setSortFiles} />
                     {!_.isEmpty(sortFiles) &&
-                        sortFiles.map((track, index) => {
-                            return <LocalTrackItem key={'sortedtrack-' + index} track={track} />;
+                        sortFiles.map((track) => {
+                            return <LocalTrackItem key={'sortedtrack-' + track.name} track={track} />;
                         })}
                     {_.isEmpty(sortFiles) &&
                         ctx.localTracks.length > 0 &&
-                        ctx.localTracks.map((track, index) => {
-                            return <LocalTrackItem key={'localtrack-' + index} track={track} />;
+                        ctx.localTracks.map((track) => {
+                            return <LocalTrackItem key={'localtrack-' + track.name} track={track} />;
                         })}
                 </div>
                 <MenuItem disableRipple={true}>

--- a/map/src/drawer/components/tracks/LocalTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackGroup.jsx
@@ -116,7 +116,7 @@ export default function LocalTrackGroup() {
                 </Box>
                 {localGpxOpen ? <ExpandLess /> : <ExpandMore />}
             </MenuItem>
-            <Collapse in={localGpxOpen} timeout="auto" unmountOnExit>
+            <Collapse in={localGpxOpen} timeout="auto">
                 <div style={{ maxHeight: '41vh', overflow: 'auto' }}>
                     <Actions files={ctx.localTracks} setSortFiles={setSortFiles} />
                     {!_.isEmpty(sortFiles) &&

--- a/map/src/drawer/components/tracks/LocalTrackGroup.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackGroup.jsx
@@ -6,9 +6,10 @@ import Actions from './Actions';
 import LocalTrackItem from './LocalTrackItem';
 import { styled } from '@mui/material/styles';
 import drawerStyles from '../../styles/DrawerStyles';
-import TracksManager from '../../../context/TracksManager';
+import TracksManager, { clearAllLocalTracks } from '../../../context/TracksManager';
 import PopperMenu from './PopperMenu';
 import _ from 'lodash';
+import { confirm } from '../../../dialogs/GlobalConfirmationDialog';
 
 export default function LocalTrackGroup() {
     const styles = drawerStyles();
@@ -28,12 +29,11 @@ export default function LocalTrackGroup() {
     };
 
     function clearLocalTracks() {
-        let selectedLocalFile = ctx.localTracks.find((t) => t.name === ctx.selectedGpxFile.name);
-        if (selectedLocalFile) {
-            ctx.setSelectedGpxFile({});
-        }
-        ctx.setLocalTracks([]);
-        localStorage.clear();
+        confirm({
+            ctx,
+            text: 'Remove all Local tracks?',
+            callback: () => clearAllLocalTracks(ctx),
+        });
     }
 
     const fileSelected = () => async (e) => {

--- a/map/src/drawer/components/tracks/LocalTrackItem.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackItem.jsx
@@ -3,9 +3,13 @@ import AppContext from '../../../context/AppContext';
 import { ListItemText, MenuItem, Switch, Tooltip, Typography } from '@mui/material';
 import _ from 'lodash';
 import TracksManager from '../../../context/TracksManager';
+import { useWindowSize } from '../../../util/hooks/useWindowSize';
+import TrackInfo from './TrackInfo';
 
 export default function LocalTrackItem({ track }) {
     const ctx = useContext(AppContext);
+
+    const [, , mobile] = useWindowSize();
 
     const ref = ctx.localTracks.find((t) => t.name === track.name);
 
@@ -88,20 +92,20 @@ export default function LocalTrackItem({ track }) {
 
     return (
         <div>
-            <MenuItem key={'track._leaflet_id' + track.name} onClick={() => addTrackToMap()}>
-                <Tooltip title={<div>{track.name}</div>}>
+            <Tooltip title={<TrackInfo file={track} />} arrow placement={mobile ? 'bottom' : 'right'}>
+                <MenuItem key={'track._leaflet_id' + track.name} onClick={() => addTrackToMap()}>
                     <ListItemText inset>
                         <Typography variant="inherit" noWrap>
                             {'* ' + track.name}
                         </Typography>
                     </ListItemText>
-                </Tooltip>
-                <Switch
-                    checked={track.selected === true || isAlreadyEdit()}
-                    onChange={(e) => onSwitchChanged(e.target.checked)}
-                    onClick={(e) => e.stopPropagation()}
-                />
-            </MenuItem>
+                    <Switch
+                        checked={track.selected === true || isAlreadyEdit()}
+                        onChange={(e) => onSwitchChanged(e.target.checked)}
+                        onClick={(e) => e.stopPropagation()}
+                    />
+                </MenuItem>
+            </Tooltip>
         </div>
     );
 }

--- a/map/src/drawer/components/tracks/LocalTrackItem.jsx
+++ b/map/src/drawer/components/tracks/LocalTrackItem.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import AppContext from '../../../context/AppContext';
 import { ListItemText, MenuItem, Switch, Tooltip, Typography } from '@mui/material';
 import _ from 'lodash';
@@ -10,6 +10,8 @@ export default function LocalTrackItem({ track }) {
     const ctx = useContext(AppContext);
 
     const [, , mobile] = useWindowSize();
+
+    const info = useMemo(() => <TrackInfo file={track} />, [track]);
 
     const ref = ctx.localTracks.find((t) => t.name === track.name);
 
@@ -92,7 +94,7 @@ export default function LocalTrackItem({ track }) {
 
     return (
         <div>
-            <Tooltip title={<TrackInfo file={track} />} arrow placement={mobile ? 'bottom' : 'right'}>
+            <Tooltip title={info} arrow placement={mobile ? 'bottom' : 'right'}>
                 <MenuItem key={'track._leaflet_id' + track.name} onClick={() => addTrackToMap()}>
                     <ListItemText inset>
                         <Typography variant="inherit" noWrap>

--- a/map/src/drawer/components/tracks/TrackInfo.jsx
+++ b/map/src/drawer/components/tracks/TrackInfo.jsx
@@ -12,7 +12,7 @@ export default function TrackInfo({ file }) {
     let timeMoving = '';
     let updownhill = '';
     let speed = '';
-    let summary = item.details?.analysis ? item.details?.analysis : localLayer?.summary;
+    let summary = item.details?.analysis ?? item.analysis ?? localLayer?.summary;
     if (item.clienttimems) {
         clienttime =
             'Upload time: ' +

--- a/map/src/drawer/components/tracks/TracksMenu.jsx
+++ b/map/src/drawer/components/tracks/TracksMenu.jsx
@@ -45,7 +45,7 @@ export default function TracksMenu() {
         setVisibleTracks({ ...visibleTracks });
     }, [ctx.localTracks]);
 
-    //get gpx files and create groups
+    // get gpx files and create groups
     useEffect(() => {
         if (!_.isEmpty(ctx.listFiles)) {
             let tg = [];

--- a/map/src/drawer/components/tracks/TracksMenu.jsx
+++ b/map/src/drawer/components/tracks/TracksMenu.jsx
@@ -189,9 +189,11 @@ export default function TracksMenu() {
                 )}
                 <LocalTrackGroup />
                 {ctx.tracksGroups &&
-                    ctx.tracksGroups.map((group, index) => {
-                        return <CloudTrackGroup key={group + index} index={index} group={group} />;
-                    })}
+                    ctx.tracksGroups
+                        .sort((a, b) => a.name > b.name)
+                        .map((group, index) => {
+                            return <CloudTrackGroup key={group + index} index={index} group={group} />;
+                        })}
             </Collapse>
         </>
     );

--- a/map/src/drawer/components/tracks/TracksMenu.jsx
+++ b/map/src/drawer/components/tracks/TracksMenu.jsx
@@ -192,7 +192,7 @@ export default function TracksMenu() {
                     ctx.tracksGroups
                         .sort((a, b) => a.name > b.name)
                         .map((group, index) => {
-                            return <CloudTrackGroup key={group + index} index={index} group={group} />;
+                            return <CloudTrackGroup key={group.name + index} index={index} group={group} />;
                         })}
             </Collapse>
         </>

--- a/map/src/drawer/components/tracks/TracksMenu.jsx
+++ b/map/src/drawer/components/tracks/TracksMenu.jsx
@@ -182,7 +182,7 @@ export default function TracksMenu() {
                 {tracksGroupsOpen ? <ExpandLess /> : <ExpandMore />}
             </MenuItem>
             {(ctx.gpxLoading || ctx.localTracksLoading) && !ctx.createTrack ? <LinearProgress /> : <></>}
-            <Collapse in={tracksGroupsOpen} timeout="auto" unmountOnExit>
+            <Collapse in={tracksGroupsOpen} timeout="auto">
                 {ctx.gpxCollection?.length > 0 && <GpxCollection />}
                 {visibleTracksOpen() && (
                     <VisibleGroup visibleTracks={visibleTracks} setVisibleTracks={setVisibleTracks} />

--- a/map/src/drawer/components/tracks/TracksMenu.jsx
+++ b/map/src/drawer/components/tracks/TracksMenu.jsx
@@ -190,7 +190,7 @@ export default function TracksMenu() {
                 <LocalTrackGroup />
                 {ctx.tracksGroups &&
                     ctx.tracksGroups
-                        .sort((a, b) => a.name > b.name)
+                        .sort((a, b) => (a.name > b.name) - (a.name < b.name))
                         .map((group, index) => {
                             return <CloudTrackGroup key={group.name + index} index={index} group={group} />;
                         })}

--- a/map/src/infoblock/components/track/dialogs/DeleteTrackDialog.jsx
+++ b/map/src/infoblock/components/track/dialogs/DeleteTrackDialog.jsx
@@ -42,7 +42,7 @@ export default function DeleteTrackDialog({ dialogOpen, setDialogOpen, setShowIn
                 newGpxFiles[ctx.selectedGpxFile.name].url = null;
                 ctx.setGpxFiles(newGpxFiles);
 
-                // delete track from menu
+                // delete track ctx.tracksGroups (used in CloudTrackGroup menu)
                 const newTracksGroups = [...ctx.tracksGroups];
                 newTracksGroups?.forEach((group) => {
                     const currentFile = group.files.findIndex((file) => file.name === ctx.selectedGpxFile.name);
@@ -52,6 +52,17 @@ export default function DeleteTrackDialog({ dialogOpen, setDialogOpen, setShowIn
                     }
                 });
                 ctx.setTracksGroups(newTracksGroups);
+
+                // delete track from ctx.listFiles.uniqueFiles
+                // used to refresh list-files in TracksManager.saveTrack
+                ctx.setListFiles((o) => {
+                    const index = o.uniqueFiles.findIndex((file) => file.name === ctx.selectedGpxFile.name);
+                    if (index !== -1) {
+                        o.uniqueFiles.splice(index, 1);
+                        o.uniqueFiles = [...o.uniqueFiles];
+                    }
+                    return { ...o };
+                });
 
                 cleanContextMenu();
             }

--- a/map/src/infoblock/components/track/dialogs/DeleteTrackDialog.jsx
+++ b/map/src/infoblock/components/track/dialogs/DeleteTrackDialog.jsx
@@ -48,6 +48,7 @@ export default function DeleteTrackDialog({ dialogOpen, setDialogOpen, setShowIn
                     const currentFile = group.files.findIndex((file) => file.name === ctx.selectedGpxFile.name);
                     if (currentFile !== -1) {
                         group.files.splice(currentFile, 1);
+                        group.files = [...group.files]; // copy group.files for CloudTrackGroups/Actions deps
                     }
                 });
                 ctx.setTracksGroups(newTracksGroups);

--- a/map/src/util/Utils.js
+++ b/map/src/util/Utils.js
@@ -53,7 +53,7 @@ export function useMutator(init) {
             setter(() => update);
         }
     };
-    return [state, mutator];
+    return [state, mutator, setter];
 }
 
 async function getFileData(file) {

--- a/map/src/util/hooks/useWindowSize.js
+++ b/map/src/util/hooks/useWindowSize.js
@@ -1,10 +1,14 @@
 import { useLayoutEffect, useState, useCallback } from 'react';
 
+const MOBILE_SCREEN_SIZE = 1000;
+
 export function useWindowSize() {
-    const [size, setSize] = useState([0, 0]);
+    const [size, setSize] = useState([0, 0, false]);
 
     const updateSize = useCallback(() => {
-        setSize([window.innerWidth, window.innerHeight]);
+        const width = window.innerWidth;
+        const mobile = !!(width && width < MOBILE_SCREEN_SIZE);
+        setSize([window.innerWidth, window.innerHeight, mobile]);
     }, []);
 
     useLayoutEffect(() => {


### PR DESCRIPTION
# Track menu sorting:

**Apply all tests on Local and Cloud folders.**

- [x] test: check A-Z and Z-A sorting
- [x] test: check Time/reverse sorting
- [x] test: check Distance/reverse sorting
- [x] test: default sorting should be "Sort by time"
- [x] test: sorting icons should hide when only 1 track in folder 
- [x] test: sorted list should be refreshed on Delete track (check both Local/Cloud delete)
- [x] test: several zero-distance tracks (for example, wpts-only) should be additionally sorted A-Z
- [x] test: try create 2-3 local tracks, edit them sequentally, check that the most freshly edited track always moves to the top
- [x] test: remember Local sorting (screenshot), then upload these 2-3 tracks into new Cloud folder and compare sorting in the Cloud

# Misc sorting:

- [x] test: Cloud tracks folders names sorted A-Z
- [x] test: Visible Local tracks names sorted A-Z
- [x] test: Visible Cloud tracks names sorted A-Z

# UI:

- [x] test: Confirmation dialog on Clear Local tracks (submenu)
- [x] test: Real clearing all Visible tracks using "Clear" submenu
- [x] test: Local tracks Tooltips (mouseover) now includes track analytics
- [x] test: Track Tooltips is now located at right side (desktop) and bottom side (mobile)

# Optimization:

**Open Test and Prod, log in both sites using your account.**

- [x] compare speed: initial full reload
- [x] compare speed: hide/show Weather menu
- [x] compare speed: full hide/show main menu
- [x] compare speed: hide/show big Cloud folders
- [x] compare speed: load/close several Cloud tracks
- [x] compare speed: switching between different not-loaded Cloud tracks
- [x] compare speed: switching between different already-loaded Cloud tracks
