### PR TITLE
Improve Login dialog: allow browser auto-login, fix annoying login field reset, allow login by Enter key #2175

### DIFF
--- a/map/src/context/AccountManager.js
+++ b/map/src/context/AccountManager.js
@@ -40,7 +40,7 @@ async function userLogin(ctx, username, pwd, setEmailError, handleClose) {
     if (await isRequestOk(response, setEmailError)) {
         setEmailError('');
         ctx.setLoginUser(username);
-        ctx.setUserEmail(username, { days: 30, SameSite: 'Strict' }); // for next login
+        ctx.setEmailCookie(username, { days: 30, SameSite: 'Strict' }); // for next login
         handleClose();
     }
 }

--- a/map/src/context/AppContext.js
+++ b/map/src/context/AppContext.js
@@ -157,7 +157,7 @@ async function addOpenedTracks(files, gpxFiles, setGpxFiles) {
     });
 }
 
-async function checkUserLogin(loginUser, setLoginUser, userEmail, setUserEmail) {
+async function checkUserLogin(loginUser, setLoginUser, emailCookie, setEmailCookie) {
     const response = await apiGet(`${process.env.REACT_APP_USER_API_SITE}/mapapi/auth/info`, {
         method: 'GET',
     });
@@ -166,7 +166,7 @@ async function checkUserLogin(loginUser, setLoginUser, userEmail, setUserEmail) 
         let newUser = user?.username;
         if (loginUser !== newUser) {
             if (newUser) {
-                setUserEmail(newUser, { days: 30, SameSite: 'Strict' });
+                setEmailCookie(newUser, { days: 30, SameSite: 'Strict' });
             }
             setLoginUser(newUser);
         }
@@ -210,7 +210,7 @@ export const AppContextProvider = (props) => {
     const [gpxLoading, setGpxLoading] = useState(false);
     const [localTracksLoading, setLocalTracksLoading] = useState(false);
     // cookie to store email logged in
-    const [userEmail, setUserEmail] = useCookie('email', '');
+    const [emailCookie, setEmailCookie] = useCookie('email', '');
     // server state of login
     const [loginUser, setLoginUser] = useState('INIT');
     const [wantDeleteAcc, setWantDeleteAcc] = useState(false);
@@ -412,7 +412,7 @@ export const AppContextProvider = (props) => {
     }, []);
 
     useEffect(() => {
-        checkUserLogin(loginUser, setLoginUser, userEmail, setUserEmail);
+        checkUserLogin(loginUser, setLoginUser, emailCookie, setEmailCookie);
     }, [loginUser]);
 
     useEffect(() => {
@@ -432,8 +432,8 @@ export const AppContextProvider = (props) => {
                 setWeatherDate,
                 weatherType,
                 setWeatherType,
-                userEmail,
-                setUserEmail,
+                emailCookie,
+                setEmailCookie,
                 listFiles,
                 setListFiles,
                 loginUser,

--- a/map/src/context/AppContext.js
+++ b/map/src/context/AppContext.js
@@ -212,7 +212,7 @@ export const AppContextProvider = (props) => {
     // cookie to store email logged in
     const [userEmail, setUserEmail] = useCookie('email', '');
     // server state of login
-    const [loginUser, setLoginUser] = useState('noCheck');
+    const [loginUser, setLoginUser] = useState('INIT');
     const [wantDeleteAcc, setWantDeleteAcc] = useState(false);
     const [listFiles, setListFiles] = useState({});
     const [gpxFiles, mutateGpxFiles, setGpxFiles] = useMutator({});
@@ -416,7 +416,7 @@ export const AppContextProvider = (props) => {
     }, [loginUser]);
 
     useEffect(() => {
-        if (loginUser !== 'noCheck') {
+        if (loginUser !== 'INIT') {
             loadListFiles(loginUser, listFiles, setListFiles, setGpxLoading, gpxFiles, setGpxFiles, setFavorites);
         }
     }, [loginUser]);

--- a/map/src/drawer/components/OsmAndDrawer.js
+++ b/map/src/drawer/components/OsmAndDrawer.js
@@ -50,7 +50,7 @@ export default function OsmAndDrawer({ toggleDrawer }) {
                     >
                         <ArrowBack />
                     </IconButton>
-                    {ctx.loginUser ? (
+                    {ctx.loginUser && ctx.loginUser != 'INIT' ? (
                         <Button className={classes.btn} onClick={openLogin}>
                             {ctx.loginUser}
                         </Button>

--- a/map/src/login/ChangeEmailDialog.jsx
+++ b/map/src/login/ChangeEmailDialog.jsx
@@ -152,7 +152,7 @@ export default function ChangeEmailDialog({ setChangeEmailFlag }) {
                                     setChangeEmailFlag(false);
                                     setEmailChanged(false);
                                     ctx.setLoginUser(null);
-                                    ctx.setUserEmail('');
+                                    ctx.setEmailCookie('');
                                     navigate('/map/' + window.location.search + window.location.hash);
                                 }}
                             >
@@ -172,7 +172,7 @@ export default function ChangeEmailDialog({ setChangeEmailFlag }) {
                         <Button
                             onClick={() => {
                                 ctx.setLoginUser(null);
-                                ctx.setUserEmail(newEmail, { days: 30, SameSite: 'Strict' });
+                                ctx.setEmailCookie(newEmail, { days: 30, SameSite: 'Strict' });
                             }}
                         >
                             Login using new credentials

--- a/map/src/login/DeleteAccountDialog.jsx
+++ b/map/src/login/DeleteAccountDialog.jsx
@@ -31,7 +31,7 @@ export default function DeleteAccountDialog({ setDeleteAccountFlag }) {
         if (ctx.loginUser) {
             return true;
         } else {
-            if (ctx.loginUser !== 'noCheck') {
+            if (ctx.loginUser !== 'INIT') {
                 ctx.setWantDeleteAcc(true);
                 navigate('/map/loginForm' + window.location.search + window.location.hash);
             }
@@ -53,7 +53,7 @@ export default function DeleteAccountDialog({ setDeleteAccountFlag }) {
 
     return (
         ctx.loginUser &&
-        ctx.loginUser !== 'noCheck' && (
+        ctx.loginUser !== 'INIT' && (
             <Dialog open={true} onClose={close}>
                 <Grid container spacing={2}>
                     <Grid item xs={11} sx={{ mb: -3 }}>

--- a/map/src/login/DeleteAccountDialog.jsx
+++ b/map/src/login/DeleteAccountDialog.jsx
@@ -21,7 +21,7 @@ export default function DeleteAccountDialog({ setDeleteAccountFlag }) {
 
     useEffect(() => {
         if (accountDeleted) {
-            ctx.setUserEmail('');
+            ctx.setEmailCookie('');
             ctx.setLoginUser(null);
             navigate('/map/loginForm' + window.location.search + window.location.hash);
         }

--- a/map/src/login/LoginDialog.js
+++ b/map/src/login/LoginDialog.js
@@ -294,6 +294,7 @@ export default function LoginDialog() {
                         }
                         setUserEmail(e.target.value);
                     }}
+                    onKeyPress={(e) => e.key === 'Enter' && handleLogin()}
                     id="username"
                     label="Email Address"
                     type="email"
@@ -310,6 +311,7 @@ export default function LoginDialog() {
                     <TextField
                         margin="dense"
                         onChange={(e) => setPwd(e.target.value)}
+                        onKeyPress={(e) => e.key === 'Enter' && handleLogin()}
                         id="pwd"
                         label={state === 'register-verify' ? 'New Password' : 'Password'}
                         type="password"

--- a/map/src/login/LoginDialog.js
+++ b/map/src/login/LoginDialog.js
@@ -72,7 +72,9 @@ export default function LoginDialog() {
         } else if (state === 'register-verify') {
             AccountManager.userActivate(ctx, userEmail, pwd, code, setEmailError, handleClose).then();
         } else {
-            AccountManager.userLogin(ctx, userEmail, pwd, setEmailError, handleClose).then();
+            if (userEmail) {
+                AccountManager.userLogin(ctx, userEmail, pwd, setEmailError, handleClose).then();
+            }
         }
     };
 

--- a/map/src/login/LoginDialog.js
+++ b/map/src/login/LoginDialog.js
@@ -28,7 +28,9 @@ export default function LoginDialog() {
 
     const classes = useStyles();
 
-    const [userEmail, setUserEmail] = useState('');
+    const [userEmail, setUserEmail] = useState(''); // first, use empty to allow browser to use auto-login
+    const [tryCookie, setTryCookie] = useState(null); // then try cookie if userEmail is still not set by browser
+
     const [pwd, setPwd] = useState();
     const [code, setCode] = useState();
     const [emailError, setEmailError] = useState(ctx.wantDeleteAcc ? 'Please log in to delete your account.' : '');
@@ -89,12 +91,18 @@ export default function LoginDialog() {
         if (ctx.loginUser && ctx.loginUser !== '') {
             getAccountInfo().then();
         } else {
-            console.log('email-set', ctx.emailCookie);
             if (ctx.emailCookie) {
-                setUserEmail(ctx.emailCookie);
+                setTimeout(() => setTryCookie(ctx.emailCookie), 500); // delay to allow browser auto-login
             }
         }
     }, [ctx.loginUser]);
+
+    useEffect(() => {
+        if (tryCookie && userEmail === '') {
+            setUserEmail(tryCookie);
+            setTryCookie(null);
+        }
+    }, [tryCookie]);
 
     async function getAccountInfo() {
         const resp = await apiGet(`${process.env.REACT_APP_USER_API_SITE}/mapapi/get-account-info`);
@@ -282,7 +290,6 @@ export default function LoginDialog() {
                         if (emailError !== '') {
                             setEmailError('');
                         }
-                        console.log('set', e.target.value);
                         setUserEmail(e.target.value);
                     }}
                     id="username"

--- a/map/src/login/LoginDialog.js
+++ b/map/src/login/LoginDialog.js
@@ -28,7 +28,7 @@ export default function LoginDialog() {
 
     const classes = useStyles();
 
-    const [userEmail, setUserEmail] = useState(ctx.userEmail);
+    const [userEmail, setUserEmail] = useState('');
     const [pwd, setPwd] = useState();
     const [code, setCode] = useState();
     const [emailError, setEmailError] = useState(ctx.wantDeleteAcc ? 'Please log in to delete your account.' : '');
@@ -89,8 +89,9 @@ export default function LoginDialog() {
         if (ctx.loginUser && ctx.loginUser !== '') {
             getAccountInfo().then();
         } else {
-            if (ctx.userEmail) {
-                setUserEmail(ctx.userEmail);
+            console.log('email-set', ctx.emailCookie);
+            if (ctx.emailCookie) {
+                setUserEmail(ctx.emailCookie);
             }
         }
     }, [ctx.loginUser]);
@@ -281,6 +282,7 @@ export default function LoginDialog() {
                         if (emailError !== '') {
                             setEmailError('');
                         }
+                        console.log('set', e.target.value);
                         setUserEmail(e.target.value);
                     }}
                     id="username"
@@ -290,7 +292,7 @@ export default function LoginDialog() {
                     variant="standard"
                     helperText={emailError ? emailError : ''}
                     error={emailError.length > 0}
-                    value={userEmail ? userEmail : ctx.userEmail}
+                    value={userEmail}
                 ></TextField>
 
                 {state === 'register' ? (


### PR DESCRIPTION
- [x] test: register new user (use new email, enter code, do login, etc)

- [x] test: do tests with Chromium, Safari, Edge (Firefox is already tested)

- [x] test: try login in by pressing Enter key on Login and/or Password fields

- [x] test: try logout/login several times when NO saved auto-login in Browser

- [x] test: try logout/login several times using ONE saved auto-login in Browser

- [x] test: try logout/login several times using SEVERAL saved auto-logins in Browser

- [x] test: after logout, try login using other E-mail (try reset auto-filled Login field to enter another E-mail)
