### PR TITLE
Update brouter.md

### DIFF
--- a/main/docs/user/navigation/routing/brouter.md
+++ b/main/docs/user/navigation/routing/brouter.md
@@ -129,8 +129,8 @@ From version 4.7.1 upwards Osmand supports the profile parameter for mapping: Si
 
 ### Examples: Osmand-profile name	Brouter-app
 ```
-[Brouter[trekking]	"trekking" profile will be used (file trekking.brf)
-[Brouter[racebike]	"racebike" profile will be used (file racebike.brf)
+Brouter[trekking]	"trekking" profile will be used (file trekking.brf)
+Brouter[racebike]	"racebike" profile will be used (file racebike.brf)
 ....
 ```
 Remark:


### PR DESCRIPTION
a minor error was still in the example:

[Brouter[treking]  was not right and confusing...
Brouter[trekking]  is right

Regards
EssBee