### PR TITLE
Fix typo

### DIFF
--- a/main/docs/user/personal/tracks.md
+++ b/main/docs/user/personal/tracks.md
@@ -114,7 +114,7 @@ Select an optimisation setting. To prevent the app from asking you the next time
 - [Coordinate input](../plan-route/coordinate-input.md) article. 
 
 
-### Plane route
+### Plan route
 
 <Tabs groupId="operating-systems">
 


### PR DESCRIPTION
The section header was "Plane Route" when it should be "Plan Route". 