### PR TITLE
Fix GPX export name not updating

### DIFF
--- a/map/src/manager/track/TracksManager.js
+++ b/map/src/manager/track/TracksManager.js
@@ -450,16 +450,13 @@ export async function getGpxFileFromTrackData(file) {
 
 function prepareTrackData({ file, getAnalysis = false }) {
     // add updated points to track
-    if (file.tracks && file.tracks[0] && validateRoutePoints(file.points)) {
+    if (file.tracks?.[0] && validateRoutePoints(file.points)) {
         file.tracks[0].points = file.points;
     }
 
     // add metaData name if it isn't exist
-    if (!file.metaData?.name) {
-        if (!file.metaData) {
-            file.metaData = {};
-        }
-        file.metaData.name = file.name;
+    if (!file.metaData?.name || file.metaData.name !== file.name) {
+        file.metaData = { ...file.metaData, name: file.name };
     }
 
     return {


### PR DESCRIPTION
Fixes #387

This updates `prepareTrackData` to also set `file.metaData.name` to `file.name` if there is a difference between the two strings. This correctly updates the GPX export XML:
```xml
<metadata>
  <name>Test</name>
</metadata>
```

I also made a quick change to `file.tracks`, but I'm happy to change this back if it doesn't fit in with the project's code style.