### PR TITLE
Clarify that marker widget information behaviour changes depending whether user is touching the screen or not

### DIFF
--- a/main/docs/user/widgets/markers.md
+++ b/main/docs/user/widgets/markers.md
@@ -20,8 +20,8 @@ Markers are temporary points indicated on the map in the form of flags. The widg
 ## Top bar widget
 
 The **Map markers bar** (Android) widget / **Distance indication - Top bar** (iOS) widget displays:
-- Distance from your current location (or the original center of the map when panning) to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
-- An arrow of the same color as the marker indicates the direction from the current location (or the original center of the map when panning)  and orientation in space of your device (heading) towards the marker.
+- Distance from your current location (or the initial map touching point when panning) to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
+- An arrow of the same color as the marker indicates the direction from the current location (or the initial map touching point when panning) and orientation in space of your device (heading) towards the marker.
 - Location Address.
 - Menu icon leading to [Map marker list](../personal/markers/#map-markers-menu).
 

--- a/main/docs/user/widgets/markers.md
+++ b/main/docs/user/widgets/markers.md
@@ -20,8 +20,8 @@ Markers are temporary points indicated on the map in the form of flags. The widg
 ## Top bar widget
 
 The **Map markers bar** (Android) widget / **Distance indication - Top bar** (iOS) widget displays:
-- Distance from your current location (or the center of the map when panning) to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
-- An arrow of the same color as the marker indicates the direction from the current location (or the center of the map when panning)  and orientation in space of your device (heading) towards the marker.
+- Distance from your current location (or the original center of the map when panning) to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
+- An arrow of the same color as the marker indicates the direction from the current location (or the original center of the map when panning)  and orientation in space of your device (heading) towards the marker.
 - Location Address.
 - Menu icon leading to [Map marker list](../personal/markers/#map-markers-menu).
 

--- a/main/docs/user/widgets/markers.md
+++ b/main/docs/user/widgets/markers.md
@@ -20,7 +20,7 @@ Markers are temporary points indicated on the map in the form of flags. The widg
 ## Top bar widget
 
 The **Map markers bar** (Android) widget / **Distance indication - Top bar** (iOS) widget displays:
-- Distance from your current location to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be choosed in the Profile settings).
+- Distance from your current location to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
 - An arrow of the same color as the marker indicates the direction from the current location and orientation in space of your device (heading) towards the marker.
 - Location Address.
 - Menu icon leading to [Map marker list](../personal/markers/#map-markers-menu).

--- a/main/docs/user/widgets/markers.md
+++ b/main/docs/user/widgets/markers.md
@@ -20,8 +20,8 @@ Markers are temporary points indicated on the map in the form of flags. The widg
 ## Top bar widget
 
 The **Map markers bar** (Android) widget / **Distance indication - Top bar** (iOS) widget displays:
-- Distance from your current location to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
-- An arrow of the same color as the marker indicates the direction from the current location and orientation in space of your device (heading) towards the marker.
+- Distance from your current location (or the center of the map when panning) to the selected point indicated by the Marker on the map ([Units of length](../personal/profiles/#general-settings) can be chosen in the Profile settings).
+- An arrow of the same color as the marker indicates the direction from the current location (or the center of the map when panning)  and orientation in space of your device (heading) towards the marker.
 - Location Address.
 - Menu icon leading to [Map marker list](../personal/markers/#map-markers-menu).
 


### PR DESCRIPTION
As reported in https://github.com/osmandapp/OsmAnd/issues/20112, the marker widget displays different information depending if map is static, or if user is touching the screen (map panning, zooming).

This PR attempts to at least clarify the situation in the documentation (although some in-app improvements would be much better, as noted in that issue)

(also fixes some English)