### PR TITLE
Fix typo in iOS purchases docs

### DIFF
--- a/main/docs/user/purchases/ios.md
+++ b/main/docs/user/purchases/ios.md
@@ -131,7 +131,7 @@ or
 
 ## Legacy Subscriptions (prior 4.0)
 
-New subscriptions became active from OsmAnd 4.3 (December 2022). All earlier subscriptions are legacy and techncically equal to "Maps subscription", though legacy subscriptions are entitled for Hourly Map updates. Users can't buy legacy subscriptions but old subscriptions are automatically renewed until the user unsubscribes (the price for them might change in the future).
+New subscriptions became active from OsmAnd 4.3 (December 2022). All earlier subscriptions are legacy and technically equal to "Maps subscription", though legacy subscriptions are entitled for Hourly Map updates. Users can't buy legacy subscriptions but old subscriptions are automatically renewed until the user unsubscribes (the price for them might change in the future).
 
 
 ## Restore Purchases


### PR DESCRIPTION
Fixing a small typo found in iOS purchase documentation.