### PR TITLE
Fix "Cloud Tracks File Sorting" Issue

### DIFF
--- a/map/src/menu/tracks/TracksMenu.jsx
+++ b/map/src/menu/tracks/TracksMenu.jsx
@@ -60,7 +60,7 @@ export default function TracksMenu() {
                 setSortFiles,
                 setSortGroups,
                 files: defGroup ? defGroup.groupFiles : [],
-                groups: defaultGroupWithFolders,
+                groups: defaultGroupWithFolders.subfolders,
             });
         }
     }, [ctx.tracksGroups]);


### PR DESCRIPTION
- Fixed bug where folders in cloud tracks component became unsorted after closing and reopening component.

- Pass `defaultGroupWithFolders.subfolders` (array) instead of the object into 'doSort'.