### PR TITLE
Fix map jitter / URL hash loop

### DIFF
--- a/map/src/map/OsmAndMap.jsx
+++ b/map/src/map/OsmAndMap.jsx
@@ -55,19 +55,17 @@ const OsmAndMap = ({ mainMenuWidth, menuInfoWidth }) => {
     const attributionSize = 300;
     const marginLeft = width / 2 - attributionSize + menuMargin;
 
-    const hashRef = useRef(null);
-
     const whenReadyHandler = (event) => {
         const { target: map } = event;
-        if (map && !hashRef.current) {
-            hashRef.current = new L.Hash(map);
+        if (map) {
+            const hash = new L.Hash(map);
             mapRef.current = map;
             if (!ctx.mapMarkerListener) {
                 ctx.setMapMarkerListener(
                     () => (lat, lng) => updateMarker({ lat, lng, setHoverPoint, hoverPointRef, ctx })
                 );
             }
-            detectGeoByIp({ map, hash: hashRef.current });
+            detectGeoByIp({ map, hash });
         }
     };
 


### PR DESCRIPTION
Issue:
- When manually changing URL hash coordinates by ± 0.1 or 0.01, the map would occasionally enter a loop of jitter / shaking (url bouncing between two near identical cords). 

Fix:
- Remove the extra Leaflet Hash instance.