### PR TITLE
Add logic to directional arrow in search results (https://github.com/osmandapp/web/issues/765)

### DIFF
--- a/map/src/menu/search/search.module.css
+++ b/map/src/menu/search/search.module.css
@@ -74,7 +74,7 @@
 }
 .placeDistance {
     font-family: Roboto !important;
-    color: #237bff !important;
+    color: #727272;
     font-size: 14px !important;
     font-weight: 400 !important;
 }

--- a/map/src/menu/search/search/SearchResultItem.jsx
+++ b/map/src/menu/search/search/SearchResultItem.jsx
@@ -84,13 +84,13 @@ export function getPropsFromSearchResultItem(props, t) {
     return { name, type, info, city };
 }
 
-export default function SearchResultItem({ item, setSearchValue, typeItem }) {
+export default function SearchResultItem({ item, setSearchValue, typeItem, bearing, isUserLocation }) {
     const ctx = useContext(AppContext);
 
     const { t } = useTranslation();
     const { ref, inView } = useInView();
 
-    const { name, info, distance, type, city, icon } = parseItem(item);
+    const { name, info, distance, type, city, icon} = parseItem(item);
     const [isHovered, setIsHovered] = useState(false);
 
     const itemId = getObjIdSearch(item);
@@ -244,14 +244,19 @@ export default function SearchResultItem({ item, setSearchValue, typeItem }) {
                                             <Typography className={styles.placeDistance}>{' · '}</Typography>
                                             <ListItemIcon
                                                 sx={{
-                                                    fill: '#237bff',
                                                     mr: -2.5,
                                                     alignItems: 'center',
                                                 }}
                                             >
-                                                <DirectionIcon />
+                                                <DirectionIcon 
+                                                    style={{
+                                                        transform: `rotate(${bearing ?? 0}deg)`,
+                                                        transformOrigin: 'center',
+                                                        fill: isUserLocation ? '#237bff' : '#727272',
+                                                    }}
+                                                    />
                                             </ListItemIcon>
-                                            <Typography className={styles.placeDistance}>{addDistance()}</Typography>
+                                            <Typography className={styles.placeDistance} style={{color: isUserLocation ? '#237bff' : '#727272',}}>{addDistance()}</Typography>
                                         </span>
                                     )}
                                 </MenuItemWithLines>

--- a/map/src/menu/search/search/SearchResults.jsx
+++ b/map/src/menu/search/search/SearchResults.jsx
@@ -10,7 +10,7 @@ import Loading from '../../errors/Loading';
 import { useGeoLocation } from '../../../util/hooks/useGeoLocation';
 import { LOCATION_UNAVAILABLE } from '../../../manager/FavoritesManager';
 import { getCenterMapLoc } from '../../../manager/MapManager';
-import { getDistance } from '../../../util/Utils';
+import { getDistance, getBearing } from '../../../util/Utils';
 import EmptySearch from '../../errors/EmptySearch';
 import { POI_LAYER_ID } from '../../../map/layers/PoiLayer';
 import useHashParams from '../../../util/hooks/useHashParams';
@@ -50,8 +50,25 @@ export default function SearchResults({ value, setOpenSearchResults, setIsMainSe
     const [locReady, setLocReady] = useState(false);
     const [errorZoom, setErrorZoom] = useState(null);
     const currentLoc = useGeoLocation(ctx);
+    const { zoom, lat = null, lon = null } = useHashParams();
+    const [debouncedLatLon, setDebouncedLatLon] = useState({ lat, lon });
 
-    const { zoom } = useHashParams();
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedLatLon({ lat, lon });
+        }, 300);
+
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [lat, lon]);
+
+    const centerFromHash = useMemo(() => {
+        return debouncedLatLon.lat != null && debouncedLatLon.lon != null 
+            ? { lat: debouncedLatLon.lat, lon: debouncedLatLon.lon } 
+            : null;
+    }, [debouncedLatLon]);
+
 
     useEffect(() => {
         if (result === EMPTY_SEARCH_RESULT) {
@@ -99,7 +116,7 @@ export default function SearchResults({ value, setOpenSearchResults, setIsMainSe
 
     const memoizedResult = useMemo(() => {
         if (!currentLoc) return null;
-        const loc = getLoc();
+        const { loc, isUser } = getLoc();
 
         if (!loc) return null;
 
@@ -116,12 +133,18 @@ export default function SearchResults({ value, setOpenSearchResults, setIsMainSe
             const lat = f?.geometry?.coordinates[1];
             const lon = f?.geometry?.coordinates[0];
             if (!lat || !lon) return f;
+            
+            const distance = lon === 0 && lat === 0 ? null : getDistance(loc.lat, loc.lng, lat, lon);
+            const bearing = lon === 0 && lat === 0 ? null : getBearing(loc.lat, loc.lng, lat, lon);
+
             return {
                 ...f,
-                locDist: lon === 0 && lat === 0 ? null : getDistance(loc.lat, loc.lng, lat, lon),
+                locDist: distance,
+                bearing: bearing,
+                isUserLocation: isUser,
             };
         });
-    }, [currentLoc, ctx.searchResult]);
+    }, [currentLoc, ctx.searchResult, centerFromHash]);
 
     useEffect(() => {
         if (!memoizedResult) return;
@@ -166,15 +189,17 @@ export default function SearchResults({ value, setOpenSearchResults, setIsMainSe
     }
 
     function getLoc() {
+        let isUser = false;
         let loc = null;
         if (currentLoc && currentLoc !== LOCATION_UNAVAILABLE) {
+            isUser = true;
             loc = currentLoc;
             setLocReady(true);
         } else if (currentLoc && currentLoc === LOCATION_UNAVAILABLE) {
             loc = getCenterMapLoc(hash);
             setLocReady(true);
         }
-        return loc;
+        return { loc, isUser };
     }
 
     useEffect(() => {
@@ -189,7 +214,7 @@ export default function SearchResults({ value, setOpenSearchResults, setIsMainSe
     }, [ctx.searchResult]);
 
     function searchByWord(value, baseSearch = false) {
-        const loc = getLoc();
+        const { loc } = getLoc();
 
         if (!loc) return;
 
@@ -235,6 +260,8 @@ export default function SearchResults({ value, setOpenSearchResults, setIsMainSe
                                         ctx.searchQuery?.type === SEARCH_TYPE_CATEGORY ? POI_LAYER_ID : SEARCH_LAYER_ID
                                     }
                                     setSearchValue={setSearchValue}
+                                    bearing={item.bearing}
+                                    isUserLocation={item.isUserLocation}
                                 />
                             ))}
                     </Box>

--- a/map/src/util/Utils.js
+++ b/map/src/util/Utils.js
@@ -107,6 +107,19 @@ export const getDistance = (lat1, lon1, lat2, lon2) => {
     return 2 * R * 1000 * Math.asin(Math.sqrt(a));
 };
 
+export const getBearing = (fromLat, fromLng, toLat, toLng) => {
+    const toDeg = r => (r * 180) / Math.PI;
+    const lat1 = toRadians(fromLat),
+          lat2 = toRadians(toLat),
+          dLng = toRadians(toLng - fromLng);
+    const y = Math.sin(dLng) * Math.cos(lat2);
+    const x = 
+        Math.cos(lat1) * Math.sin(lat2) 
+        - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
+
+    return ((toDeg(Math.atan2(y,x)) + 360) % 360); // clockwise degrees
+}
+
 const toRadians = (angdeg) => {
     return (angdeg / 180.0) * Math.PI;
 };
@@ -359,6 +372,7 @@ const Utils = {
     getFileData,
     getFileInfo,
     getDistance,
+    getBearing,
     getPointsDist,
     hexToRgba,
     numberToRgba,


### PR DESCRIPTION
- Add util to calculate angle between two points of coordinates
- Add logic to search results component for directional arrow: 
    - debounced lat/lon changes (300ms) to avoid excessive recalculations when moving the map
    - pass bearing and type of user location (geolocation or center of map/hash) down to child
- SearchResultItem component:
    - render arrow and distance blue is geolocation is enabled in browser by user
    - not enabled location service => arrow and distance grey 
    - if bearing is undefined default to no rotation.
    
- issue: https://github.com/osmandapp/web/issues/765#issuecomment-2893821985 