### PR TITLE
Pricing page: Make "FastSpring account management portal" a link

### DIFF
--- a/map/src/resources/translations/en/web-translation.json
+++ b/map/src/resources/translations/en/web-translation.json
@@ -111,7 +111,7 @@
   "purchase_type_one_time_purchase": "One-time purchase",
   "label_pricing": "Pricing",
   "subtitle_choose_your_ideal_osmand_plan": "Choose your ideal OsmAnd plan: Get started for free, select a flexible subscription, or make a one-time purchase",
-  "notice_fastspring_purchase_info": "Online purchases are provided by FastSpring, an authorized reseller. Subscriptions automatically renew unless canceled before the renewal date. You can cancel or renew your subscription on the FastSpring account management portal.",
+  "notice_fastspring_purchase_info": "Online purchases are provided by FastSpring, an authorized reseller. Subscriptions automatically renew unless canceled before the renewal date. You can cancel or renew your subscription on the <portalLink>FastSpring account management portal</portalLink>.",
   "feature_offline_navigation_desc": "Turn-by-turn voice guidance, traffic warnings, and lane guidance, all available offline",
   "feature_navigation_by_planned_tracks": "Navigation by planned tracks",
   "feature_navigation_by_planned_tracks_desc": "Follow your GPX tracks with turn-by-turn guidance, or snap to roads for detailed navigation and road information",

--- a/map/src/shop/PricingPage.jsx
+++ b/map/src/shop/PricingPage.jsx
@@ -1,9 +1,9 @@
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, CircularProgress, Link, Typography } from '@mui/material';
 import HeaderMenu from '../frame/components/header/HeaderMenu';
 import React, { Suspense, useContext, useEffect, useState } from 'react';
 import ProductCard from './products/ProductCard';
 import styles from './shop.module.css';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { purchase } from './products/ProductManager';
 import EmptyLoginDialog from '../login/dialogs/EmptyLoginDialog';
 import { updatePrices } from '../login/fs/FastSpringHelper';
@@ -109,7 +109,9 @@ export default function PricingPage() {
                             ))}
                         </Box>
                     )}
-                    <Typography className={styles.pricingDesc}>{t('web:notice_fastspring_purchase_info')}</Typography>
+                    <Typography className={styles.pricingDesc}>
+                        <Trans i18nKey="web:notice_fastspring_purchase_info" components={{ portalLink: <Link href="https://osmand.onfastspring.com/account" /> }} />
+                    </Typography>
                     <Suspense fallback={<CircularProgress />}>
                         <FeaturesTable />
                     </Suspense>


### PR DESCRIPTION
Update the English translation. Other translations will continue to work but will not show the new link until they are updated.

---
Fixes #1043.

I tested this on my computer with `yarn start` and it appeared to work.