### PR TITLE
Cover map/src/util with unit tests

### DIFF
--- a/map/src/util/Utils.js
+++ b/map/src/util/Utils.js
@@ -192,9 +192,17 @@ export function cloneTrackObject(track) {
 // Used ONLY when creating a new file
 export function sanitizedFileName(filename, isFavoriteGroup = false) {
     const truncate = (sanitized, length) => {
-        const uint8Array = new TextEncoder().encode(sanitized);
-        const truncated = uint8Array.slice(0, length);
-        return new TextDecoder().decode(truncated);
+        const bytes = new TextEncoder().encode(sanitized);
+        if (bytes.length <= length) {
+            return sanitized;
+        }
+        // step back over the continuation bytes, so a multi-byte character is never cut in half
+        let end = length;
+        while (end > 0 && (bytes[end] & 0xc0) === 0x80) {
+            end--;
+        }
+
+        return new TextDecoder().decode(bytes.slice(0, end));
     };
 
     const newlineRe = /\n/g;
@@ -301,7 +309,7 @@ export function createUrlParams(params) {
         .replaceAll('%2C', ',')
         .replaceAll('%3A', ':')
         .replaceAll('%3B', ';');
-    if (Object.keys(pretty).length > 0) {
+    if (pretty.length > 0) {
         pretty = '?' + pretty;
     }
     return pretty;

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -36,7 +36,6 @@ module.exports = {
         FavoritesManager$: `${STUBS}/empty.js`,
         MarkerOptions$: `${STUBS}/empty.js`,
         'geoRouter(\\.js)?$': `${STUBS}/empty.js`,
-        'GzipBase64\\.mjs$': `${STUBS}/empty.js`,
         '/i18n$': `${STUBS}/empty.js`,
         useInitialFilesLoad$: `${STUBS}/empty.js`,
         // app sources

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     testMatch: ['<rootDir>/src/tests/**/*.test.js'],
     setupFiles: ['<rootDir>/src/util/setup.js'],
     clearMocks: true,
+    restoreMocks: true,
     transform: {
         '^.+\\.[mc]?jsx?$': ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }],
     },

--- a/tests/unit/src/tests/util/01-utils.test.js
+++ b/tests/unit/src/tests/util/01-utils.test.js
@@ -204,7 +204,8 @@ describe('isToday / isYesterday', () => {
     });
 
     test('yesterday', () => {
-        const yesterday = new Date(Date.now() - DAY_MS);
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1); // a calendar day, not 24 hours - dst days are shorter or longer
         expect(isYesterday(yesterday)).toBe(true);
         expect(isToday(yesterday)).toBe(false);
     });

--- a/tests/unit/src/tests/util/01-utils.test.js
+++ b/tests/unit/src/tests/util/01-utils.test.js
@@ -1,0 +1,217 @@
+import {
+    areSetsEqual,
+    createUrlParams,
+    decodeString,
+    encodeString,
+    formatMeters,
+    getBearing,
+    getDistance,
+    isToday,
+    isYesterday,
+    quickNaNfix,
+    sanitizedFileName,
+    toHHMMSS,
+    truncateText,
+} from '@map/util/Utils';
+
+const KYIV = [50.45, 30.523];
+
+describe('getDistance', () => {
+    test('same point is zero', () => {
+        expect(getDistance(...KYIV, ...KYIV)).toBe(0);
+    });
+
+    test('one degree of latitude is about 111 km', () => {
+        expect(getDistance(0, 0, 1, 0) / 1000).toBeCloseTo(111.2, 1);
+    });
+
+    test('symmetric', () => {
+        expect(getDistance(...KYIV, 50.5, 30.6)).toBeCloseTo(getDistance(50.5, 30.6, ...KYIV), 6);
+    });
+});
+
+describe('getBearing', () => {
+    test('cardinal directions, clockwise from north', () => {
+        expect(getBearing(0, 0, 1, 0)).toBeCloseTo(0, 6);
+        expect(getBearing(0, 0, 0, 1)).toBeCloseTo(90, 6);
+        expect(getBearing(0, 0, 0, -1)).toBeCloseTo(270, 6);
+    });
+
+    test('south is 180, never negative', () => {
+        const bearing = getBearing(0, 0, -1, 0);
+        expect(bearing).toBeCloseTo(180, 6);
+        expect(bearing).toBeGreaterThanOrEqual(0);
+    });
+});
+
+describe('formatMeters', () => {
+    test('meters below a kilometer, rounded', () => {
+        expect(formatMeters(0)).toBe('0 m');
+        expect(formatMeters(1)).toBe('1 m');
+        expect(formatMeters(999.4)).toBe('999 m');
+    });
+
+    test('kilometers with two decimals', () => {
+        expect(formatMeters(1000)).toBe('1.00 km');
+        expect(formatMeters(1500)).toBe('1.50 km');
+        expect(formatMeters(12345)).toBe('12.35 km');
+    });
+});
+
+describe('toHHMMSS', () => {
+    test('milliseconds to hh:mm:ss', () => {
+        expect(toHHMMSS(0)).toBe('00:00:00.00');
+        expect(toHHMMSS(1000)).toBe('00:00:01.00');
+        expect(toHHMMSS(61000)).toBe('00:01:01.00');
+        expect(toHHMMSS(3661000)).toBe('01:01:01.00');
+    });
+
+    test('over ten hours keeps two digits', () => {
+        expect(toHHMMSS(36000000)).toBe('10:00:00.00');
+    });
+});
+
+describe('quickNaNfix', () => {
+    test('the NaN marker of elevation becomes null', () => {
+        expect(quickNaNfix('{"ele": 99999}')).toBe('{"ele":null}');
+        expect(quickNaNfix('{"ele":99999.0}')).toBe('{"ele":null}');
+    });
+
+    test('bare NaN becomes null', () => {
+        expect(quickNaNfix('{"ele":NaN,"lat": NaN}')).toBe('{"ele":null,"lat":null}');
+    });
+
+    test('infinite speeds become null', () => {
+        expect(quickNaNfix('{"speed": Infinity,"avgSpeed":Infinity,"maxSpeed":Infinity}')).toBe(
+            '{"speed":null,"avgSpeed":null,"maxSpeed":null}'
+        );
+    });
+
+    test('valid json is untouched', () => {
+        expect(quickNaNfix('{"ele":123,"speed":1.5}')).toBe('{"ele":123,"speed":1.5}');
+    });
+});
+
+describe('sanitizedFileName', () => {
+    test('illegal characters become spaces', () => {
+        expect(sanitizedFileName('a/b?c<d>e:f*g|h"i')).toBe('a b c d e f g h i');
+    });
+
+    test('a slash is allowed in a favorite group', () => {
+        expect(sanitizedFileName('a/b', true)).toBe('a/b');
+    });
+
+    test('newlines are dropped, not replaced', () => {
+        expect(sanitizedFileName('Track\nname')).toBe('Trackname');
+    });
+
+    test('double spaces are collapsed and the result is trimmed', () => {
+        expect(sanitizedFileName('  Track   name  ')).toBe('Track name');
+    });
+
+    test('windows reserved names and dot-only names', () => {
+        expect(sanitizedFileName('con')).toBe('');
+        expect(sanitizedFileName('..')).toBe('');
+    });
+
+    test('unicode survives', () => {
+        expect(sanitizedFileName('Трек №1')).toBe('Трек №1');
+    });
+
+    test('cut at 255 bytes', () => {
+        const name = 'a'.repeat(300);
+        expect(sanitizedFileName(name)).toBe('a'.repeat(255));
+    });
+
+    test('a multi-byte character is never cut in half', () => {
+        const name = 'я'.repeat(200); // 2 bytes each
+        const result = sanitizedFileName(name);
+        expect(result).not.toContain('\uFFFD');
+        expect(new TextEncoder().encode(result).length).toBeLessThanOrEqual(255);
+        expect(result).toBe('я'.repeat(127));
+    });
+});
+
+describe('areSetsEqual', () => {
+    test('same content', () => {
+        const set = new Set([1, 2]);
+        expect(areSetsEqual(set, set)).toBe(true);
+        expect(areSetsEqual(new Set([1, 2]), new Set([2, 1]))).toBe(true);
+    });
+
+    test('different content or size', () => {
+        expect(areSetsEqual(new Set([1, 2]), new Set([1, 3]))).toBe(false);
+        expect(areSetsEqual(new Set([1]), new Set([1, 2]))).toBe(false);
+        expect(areSetsEqual(null, new Set([1]))).toBe(false);
+    });
+});
+
+describe('createUrlParams', () => {
+    test('query string with a leading question mark', () => {
+        expect(createUrlParams({ lat: 50.45, lon: 30.523 })).toBe('?lat=50.45&lon=30.523');
+    });
+
+    test('comma, colon and semicolon are kept readable', () => {
+        expect(createUrlParams({ bbox: '1,2', time: '10:00', list: 'a;b' })).toBe('?bbox=1,2&time=10:00&list=a;b');
+    });
+
+    test('other characters are still escaped', () => {
+        expect(createUrlParams({ name: 'Track name' })).toBe('?name=Track+name');
+    });
+
+    test('no params - no question mark', () => {
+        expect(createUrlParams({})).toBe('');
+        expect(createUrlParams({ q: '' })).toBe('?q=');
+    });
+});
+
+describe('encodeString / decodeString', () => {
+    test('round-trip, unicode included', () => {
+        for (const value of ['Track', 'Трек №1 / 2', '', '{"a":1}']) {
+            expect(decodeString(encodeString(value))).toBe(value);
+        }
+    });
+
+    test('encoding a non-string returns null', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        expect(encodeString(123)).toBeNull();
+        expect(encodeString(null)).toBeNull();
+    });
+
+    test('decoding garbage returns null', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        expect(decodeString('!!!not base64!!!')).toBeNull();
+    });
+});
+
+describe('truncateText', () => {
+    test('shorter than the limit is untouched', () => {
+        expect(truncateText('Track', 10)).toBe('Track');
+        expect(truncateText('Track', 5)).toBe('Track');
+    });
+
+    test('longer is cut and gets an ellipsis', () => {
+        expect(truncateText('Track name', 5)).toBe('Track...');
+    });
+});
+
+describe('isToday / isYesterday', () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    test('today', () => {
+        expect(isToday(new Date())).toBe(true);
+        expect(isYesterday(new Date())).toBe(false);
+    });
+
+    test('yesterday', () => {
+        const yesterday = new Date(Date.now() - DAY_MS);
+        expect(isYesterday(yesterday)).toBe(true);
+        expect(isToday(yesterday)).toBe(false);
+    });
+
+    test('a week ago is neither', () => {
+        const weekAgo = new Date(Date.now() - 7 * DAY_MS);
+        expect(isToday(weekAgo)).toBe(false);
+        expect(isYesterday(weekAgo)).toBe(false);
+    });
+});

--- a/tests/unit/src/tests/util/02-decode-geometry.test.js
+++ b/tests/unit/src/tests/util/02-decode-geometry.test.js
@@ -1,0 +1,117 @@
+import { decodeSimplifiedGeometry } from '@map/util/decodeSimplifiedGeometry';
+import { distance, encodeGeometry } from '../../util/fixtures/geometry';
+
+// the z18+8 storage grid is about 0.6 m, so a decoded point must land within a couple of cells
+const GRID_TOLERANCE_M = 2;
+
+function expectSameTrack(decoded, expected) {
+    expect(decoded).toHaveLength(expected.length);
+    decoded.forEach((segment, s) => {
+        expect(segment).toHaveLength(expected[s].length);
+        segment.forEach((point, i) => {
+            const [latitude, longitude] = expected[s][i];
+            expect(distance(point.latitude, point.longitude, latitude, longitude)).toBeLessThan(GRID_TOLERANCE_M);
+        });
+    });
+}
+
+test('empty input', () => {
+    expect(decodeSimplifiedGeometry('')).toEqual([]);
+    expect(decodeSimplifiedGeometry(null)).toEqual([]);
+    expect(decodeSimplifiedGeometry(undefined)).toEqual([]);
+});
+
+test('no segments', () => {
+    expect(decodeSimplifiedGeometry(encodeGeometry([]))).toEqual([]);
+});
+
+test('single segment', () => {
+    const track = [
+        [
+            [50.45, 30.523],
+            [50.4501, 30.5231],
+            [50.4502, 30.5233],
+        ],
+    ];
+
+    expectSameTrack(decodeSimplifiedGeometry(encodeGeometry(track)), track);
+});
+
+test('several segments', () => {
+    const track = [
+        [
+            [50.45, 30.523],
+            [50.451, 30.524],
+        ],
+        [
+            [49.84, 24.03],
+            [49.841, 24.031],
+            [49.842, 24.032],
+        ],
+    ];
+
+    expectSameTrack(decodeSimplifiedGeometry(encodeGeometry(track)), track);
+});
+
+test('empty segments are dropped', () => {
+    const decoded = decodeSimplifiedGeometry(
+        encodeGeometry([
+            [],
+            [
+                [50.45, 30.523],
+                [50.451, 30.524],
+            ],
+        ])
+    );
+    expect(decoded).toHaveLength(1);
+    expect(decoded[0]).toHaveLength(2);
+});
+
+test('negative coordinates and deltas in both directions', () => {
+    const track = [
+        [
+            [-33.87, -151.21],
+            [-33.871, -151.212],
+            [-33.869, -151.209],
+        ],
+    ];
+
+    expectSameTrack(decodeSimplifiedGeometry(encodeGeometry(track)), track);
+});
+
+test('the extremes of the mercator grid', () => {
+    const track = [
+        [
+            [0, 0],
+            [0, 179.9],
+            [0, -179.9],
+            [84, 0],
+            [-84, 0],
+        ],
+    ];
+
+    expectSameTrack(decodeSimplifiedGeometry(encodeGeometry(track)), track);
+});
+
+test('a long jump needs a multi-byte varint', () => {
+    const track = [
+        [
+            [50.45, 30.523],
+            [51.5, 0.12], // Kyiv -> London in one delta
+        ],
+    ];
+
+    expectSameTrack(decodeSimplifiedGeometry(encodeGeometry(track)), track);
+});
+
+test('a truncated payload is reported, not silently decoded', () => {
+    const b64 = encodeGeometry([
+        [
+            [50.45, 30.523],
+            [50.451, 30.524],
+        ],
+    ]);
+    const cut = Buffer.from(b64, 'base64').subarray(0, 3).toString('base64');
+
+    expect(() => decodeSimplifiedGeometry(cut)).toThrow('Corrupted varint geometry');
+});

--- a/tests/unit/src/tests/util/02-decode-geometry.test.js
+++ b/tests/unit/src/tests/util/02-decode-geometry.test.js
@@ -1,6 +1,8 @@
 import { decodeSimplifiedGeometry } from '@map/util/decodeSimplifiedGeometry';
 import { distance, encodeGeometry } from '../../util/fixtures/geometry';
 
+// the encoder used here is a copy of the server one - see the note in fixtures/geometry.js
+
 // the z18+8 storage grid is about 0.6 m, so a decoded point must land within a couple of cells
 const GRID_TOLERANCE_M = 2;
 

--- a/tests/unit/src/tests/util/03-date-fmt.test.js
+++ b/tests/unit/src/tests/util/03-date-fmt.test.js
@@ -1,0 +1,93 @@
+import { fmt, localizeWeekTokens } from '@map/util/dateFmt';
+
+// i18next is not initialised in tests, so the module falls back to navigator.language
+function withLanguage(language, run) {
+    const prev = navigator.language;
+    Object.defineProperty(navigator, 'language', { value: language, configurable: true });
+    try {
+        run();
+    } finally {
+        Object.defineProperty(navigator, 'language', { value: prev, configurable: true });
+    }
+}
+
+const SEP_4_2025 = new Date(2025, 8, 4); // Thursday
+
+describe('localizeWeekTokens', () => {
+    test('empty input is returned as is', () => {
+        expect(localizeWeekTokens('')).toBe('');
+        expect(localizeWeekTokens(null)).toBeNull();
+        expect(localizeWeekTokens(undefined)).toBeUndefined();
+    });
+
+    test('two-letter tokens become weekday names', () => {
+        withLanguage('en-US', () => {
+            expect(localizeWeekTokens('Mo-Fr')).toBe('Mon-Fri');
+            expect(localizeWeekTokens('Sa,Su')).toBe('Sat,Sun');
+        });
+    });
+
+    test('the rest of the schedule is untouched', () => {
+        withLanguage('en-US', () => {
+            expect(localizeWeekTokens('Mo-Fr 09:00-18:00; Sa 10:00-14:00')).toBe(
+                'Mon-Fri 09:00-18:00; Sat 10:00-14:00'
+            );
+        });
+    });
+
+    test('a token inside a word is not a token', () => {
+        withLanguage('en-US', () => {
+            expect(localizeWeekTokens('Mode Sunny Wet')).toBe('Mode Sunny Wet');
+        });
+    });
+
+    test('localized weekdays', () => {
+        withLanguage('uk', () => {
+            expect(localizeWeekTokens('Mo-Fr')).toBe('Пн-Пт');
+        });
+    });
+});
+
+describe('fmt', () => {
+    test('MMMdY', () => {
+        withLanguage('en-US', () => {
+            expect(fmt.MMMdY(SEP_4_2025)).toBe('Sep 4, 2025');
+        });
+    });
+
+    test('ddMMyyyy and ddMM keep two digits', () => {
+        withLanguage('en-GB', () => {
+            expect(fmt.ddMMyyyy(SEP_4_2025)).toBe('04/09/2025');
+            expect(fmt.ddMM(SEP_4_2025)).toBe('04/09');
+        });
+    });
+
+    test('short weekday is capitalized and loses the trailing dot', () => {
+        withLanguage('en-US', () => {
+            expect(fmt.wkShort(SEP_4_2025)).toBe('Thu');
+        });
+        withLanguage('uk', () => {
+            expect(fmt.wkShort(SEP_4_2025)).toBe('Чт');
+        });
+    });
+
+    test('long weekday and month are capitalized', () => {
+        withLanguage('uk', () => {
+            expect(fmt.wkLong(SEP_4_2025)).toMatch(/^Ч/);
+            expect(fmt.monthYearLong(SEP_4_2025)).toMatch(/^В/);
+        });
+    });
+
+    test('time is 24-hour and zero padded', () => {
+        withLanguage('en-US', () => {
+            expect(fmt.time24(new Date(2025, 8, 4, 0, 5))).toBe('00:05');
+            expect(fmt.time24(new Date(2025, 8, 4, 18, 30))).toBe('18:30');
+        });
+    });
+
+    test('date and time together', () => {
+        withLanguage('en-US', () => {
+            expect(fmt.dateTimeShort(new Date(2025, 8, 4, 18, 30))).toBe('Sep 4, 2025 – 18:30');
+        });
+    });
+});

--- a/tests/unit/src/tests/util/03-date-fmt.test.js
+++ b/tests/unit/src/tests/util/03-date-fmt.test.js
@@ -88,6 +88,29 @@ describe('fmt', () => {
     test('date and time together', () => {
         withLanguage('en-US', () => {
             expect(fmt.dateTimeShort(new Date(2025, 8, 4, 18, 30))).toBe('Sep 4, 2025 – 18:30');
+            expect(fmt.wkLongTime(new Date(2025, 8, 4, 18, 30))).toBe('Thursday, 18:30');
+        });
+    });
+
+    test('long month, with and without the year', () => {
+        withLanguage('en-US', () => {
+            expect(fmt.dMMMMY(SEP_4_2025)).toBe('September 4, 2025');
+            expect(fmt.dMMMM(SEP_4_2025)).toBe('September 4');
+        });
+        // the day comes first in most locales, the format follows the locale rather than the name
+        withLanguage('en-GB', () => {
+            expect(fmt.dMMMMY(SEP_4_2025)).toBe('4 September 2025');
+            expect(fmt.dMMMM(SEP_4_2025)).toBe('4 September');
+        });
+    });
+
+    test('month always before the day, whatever the locale order is', () => {
+        withLanguage('en-US', () => {
+            expect(fmt.monthShortDay(SEP_4_2025)).toBe('Sep 4');
+        });
+        // uk puts the day first in its own formats, this one keeps the month first
+        withLanguage('uk', () => {
+            expect(fmt.monthShortDay(SEP_4_2025)).toBe('вер. 4');
         });
     });
 });

--- a/tests/unit/src/tests/util/04-app-data-version.test.js
+++ b/tests/unit/src/tests/util/04-app-data-version.test.js
@@ -1,0 +1,108 @@
+import {
+    APP_DATA_VERSION,
+    FAVORITES_DB_NAME,
+    FAVORITES_IDB_DATA_VERSION,
+    IDB_VERSIONS_STORAGE_KEY,
+    IDB_VERSION_APP,
+    IDB_VERSION_FAVORITES,
+    IDB_VERSION_LOCAL_TRACKS,
+    TRACKS_DB_NAME,
+    TRACKS_IDB_DATA_VERSION,
+    ensureAppDataVersion,
+} from '@map/util/appDataVersion';
+import { fakeIndexedDb, removeIndexedDb } from '../../util/indexedDb';
+
+const CURRENT_STATE = {
+    [IDB_VERSION_APP]: APP_DATA_VERSION,
+    [IDB_VERSION_FAVORITES]: FAVORITES_IDB_DATA_VERSION,
+    [IDB_VERSION_LOCAL_TRACKS]: TRACKS_IDB_DATA_VERSION,
+};
+
+let deleted;
+
+function storedState() {
+    return JSON.parse(localStorage.getItem(IDB_VERSIONS_STORAGE_KEY));
+}
+
+function setStoredState(value) {
+    localStorage.setItem(IDB_VERSIONS_STORAGE_KEY, typeof value === 'string' ? value : JSON.stringify(value));
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    deleted = fakeIndexedDb();
+});
+
+afterEach(() => {
+    removeIndexedDb();
+});
+
+test('first run: both databases are cleared and the current versions are stored', async () => {
+    await ensureAppDataVersion();
+
+    expect(deleted).toEqual(expect.arrayContaining([FAVORITES_DB_NAME, TRACKS_DB_NAME]));
+    expect(deleted).toHaveLength(2);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('everything is up to date: nothing is cleared', async () => {
+    setStoredState(CURRENT_STATE);
+
+    await ensureAppDataVersion();
+
+    expect(deleted).toEqual([]);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('outdated app version resets both databases', async () => {
+    setStoredState({ ...CURRENT_STATE, [IDB_VERSION_APP]: APP_DATA_VERSION - 1 });
+
+    await ensureAppDataVersion();
+
+    expect(deleted).toHaveLength(2);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('outdated favorites version clears only that database', async () => {
+    setStoredState({ ...CURRENT_STATE, [IDB_VERSION_FAVORITES]: FAVORITES_IDB_DATA_VERSION - 1 });
+
+    await ensureAppDataVersion();
+
+    expect(deleted).toEqual([FAVORITES_DB_NAME]);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('outdated tracks version clears only that database', async () => {
+    setStoredState({ ...CURRENT_STATE, [IDB_VERSION_LOCAL_TRACKS]: TRACKS_IDB_DATA_VERSION - 1 });
+
+    await ensureAppDataVersion();
+
+    expect(deleted).toEqual([TRACKS_DB_NAME]);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('broken json is treated as no state at all', async () => {
+    setStoredState('{not json');
+
+    await ensureAppDataVersion();
+
+    expect(deleted).toHaveLength(2);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('a state with a missing field is not trusted', async () => {
+    setStoredState({ [IDB_VERSION_APP]: APP_DATA_VERSION });
+
+    await ensureAppDataVersion();
+
+    expect(deleted).toHaveLength(2);
+    expect(storedState()).toEqual(CURRENT_STATE);
+});
+
+test('no indexedDB at all: the state is still stored', async () => {
+    removeIndexedDb();
+
+    await ensureAppDataVersion();
+
+    expect(storedState()).toEqual(CURRENT_STATE);
+});

--- a/tests/unit/src/tests/util/05-lang.test.js
+++ b/tests/unit/src/tests/util/05-lang.test.js
@@ -1,0 +1,58 @@
+import { getLanguageName } from '@map/util/LanguageDisplayName';
+import { normalizeLang } from '@map/util/lang';
+
+describe('normalizeLang', () => {
+    test('plain codes are kept', () => {
+        expect(normalizeLang('en')).toBe('en');
+        expect(normalizeLang('en-US')).toBe('en-US');
+        expect(normalizeLang('uk')).toBe('uk');
+    });
+
+    test('known aliases', () => {
+        expect(normalizeLang('yue')).toBe('zhyue');
+        expect(normalizeLang('b+be+Latn')).toBe('be-BY');
+    });
+
+    test('modern android qualifiers lose the b+ prefix', () => {
+        expect(normalizeLang('b+sr+Cyrl')).toBe('sr-Cyrl');
+        expect(normalizeLang('b+zh+Hant')).toBe('zh-Hant');
+    });
+
+    test('classic android region qualifiers lose the r', () => {
+        expect(normalizeLang('en-rGB')).toBe('en-GB');
+        expect(normalizeLang('pt-rBR')).toBe('pt-BR');
+    });
+
+    test('invalid input falls back to en-US', () => {
+        expect(normalizeLang(null)).toBe('en-US');
+        expect(normalizeLang(undefined)).toBe('en-US');
+        expect(normalizeLang('')).toBe('en-US');
+        expect(normalizeLang(42)).toBe('en-US');
+    });
+});
+
+describe('getLanguageName', () => {
+    test('language codes become english names', () => {
+        expect(getLanguageName('en')).toBe('English');
+        expect(getLanguageName('uk')).toBe('Ukrainian');
+        expect(getLanguageName('DE')).toBe('German');
+    });
+
+    test('a region is part of the name', () => {
+        expect(getLanguageName('en-US')).toBe('American English');
+        expect(getLanguageName('uk-UA')).toBe('Ukrainian (Ukraine)');
+    });
+
+    test('an invalid tag is returned as is', () => {
+        expect(getLanguageName('uk_UA')).toBe('uk_UA');
+    });
+
+    test('empty input is an empty string', () => {
+        expect(getLanguageName('')).toBe('');
+        expect(getLanguageName(null)).toBe('');
+    });
+
+    test('an unknown code is returned as is', () => {
+        expect(getLanguageName('zzz')).toBe('zzz');
+    });
+});

--- a/tests/unit/src/tests/util/06-gzip.test.js
+++ b/tests/unit/src/tests/util/06-gzip.test.js
@@ -1,0 +1,56 @@
+import { compressFromJSON, compressFromString, decompressToJSON, decompressToString } from '@map/util/GzipBase64.mjs';
+import { compressJSONToBlob, compressStringToBlob } from '@map/util/GzipCompression';
+import { gunzipSync } from 'node:zlib';
+
+// jsdom Blob has no arrayBuffer()
+function readBlob(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(Buffer.from(reader.result));
+        reader.onerror = reject;
+        reader.readAsArrayBuffer(blob);
+    });
+}
+
+describe('GzipBase64', () => {
+    test('string round-trip', async () => {
+        for (const value of ['', 'Track', 'Трек №1']) {
+            expect(await decompressToString(await compressFromString(value))).toBe(value);
+        }
+    });
+
+    test('a string longer than the 0x8000 chunk of u8toBytes', async () => {
+        const value = Array.from({ length: 100000 }, (unused, i) => String.fromCharCode(33 + (i % 90))).join('');
+        expect(await decompressToString(await compressFromString(value))).toBe(value);
+    });
+
+    test('json round-trip', async () => {
+        const obj = { name: 'Трек', points: [{ lat: 50.45, lng: 30.523 }], nested: { a: [1, 2, 3] } };
+        expect(await decompressToJSON(await compressFromJSON(obj))).toEqual(obj);
+    });
+
+    test('the result is base64 and shorter than a repetitive input', async () => {
+        const packed = await compressFromString('a'.repeat(10000));
+        expect(packed).toMatch(/^[A-Za-z0-9+/]+=*$/);
+        expect(packed.length).toBeLessThan(10000);
+    });
+
+    test('empty input decompresses to null', async () => {
+        expect(await decompressToJSON('')).toBeNull();
+        expect(await decompressToJSON(null)).toBeNull();
+    });
+});
+
+describe('GzipCompression', () => {
+    test('a string becomes a gzipped blob', async () => {
+        const blob = compressStringToBlob('Трек №1');
+        expect(blob.type).toBe('application/gzip');
+        expect(gunzipSync(await readBlob(blob)).toString('utf-8')).toBe('Трек №1');
+    });
+
+    test('a json object becomes a gzipped blob', async () => {
+        const obj = { name: 'Трек', points: [1, 2, 3] };
+        const blob = compressJSONToBlob(obj);
+        expect(JSON.parse(gunzipSync(await readBlob(blob)).toString('utf-8'))).toEqual(obj);
+    });
+});

--- a/tests/unit/src/tests/util/06-gzip.test.js
+++ b/tests/unit/src/tests/util/06-gzip.test.js
@@ -2,6 +2,22 @@ import { compressFromJSON, compressFromString, decompressToJSON, decompressToStr
 import { compressJSONToBlob, compressStringToBlob } from '@map/util/GzipCompression';
 import { gunzipSync } from 'node:zlib';
 
+// deterministic noise: gzip must not be able to compress it away
+function noisyAscii(length) {
+    let seed = 0x2f6e2b1;
+    let out = '';
+    for (let i = 0; i < length; i++) {
+        seed ^= seed << 13;
+        seed |= 0;
+        seed ^= seed >>> 17;
+        seed ^= seed << 5;
+        seed |= 0;
+        out += String.fromCharCode(33 + (Math.abs(seed) % 90));
+    }
+
+    return out;
+}
+
 // jsdom Blob has no arrayBuffer()
 function readBlob(blob) {
     return new Promise((resolve, reject) => {
@@ -19,9 +35,13 @@ describe('GzipBase64', () => {
         }
     });
 
-    test('a string longer than the 0x8000 chunk of u8toBytes', async () => {
-        const value = Array.from({ length: 100000 }, (unused, i) => String.fromCharCode(33 + (i % 90))).join('');
-        expect(await decompressToString(await compressFromString(value))).toBe(value);
+    test('a payload that takes more than one chunk of u8toBytes', async () => {
+        const value = noisyAscii(50000);
+        const packed = await compressFromString(value);
+
+        // u8toBytes walks the compressed bytes in 0x8000 chunks, so the payload has to cross that
+        expect(Buffer.from(packed, 'base64').length).toBeGreaterThan(0x8000);
+        expect(await decompressToString(packed)).toBe(value);
     });
 
     test('json round-trip', async () => {

--- a/tests/unit/src/util/fixtures/geometry.js
+++ b/tests/unit/src/util/fixtures/geometry.js
@@ -1,0 +1,73 @@
+// Mirrors the server-side encoder net.osmand.server.osmgpx.TrackSimplifyEncoder,
+// so the decoder under test is checked against an independent implementation.
+
+const STORE_ZOOM = 18;
+const STORE_SHIFT = 31 - (STORE_ZOOM + 8); // = 5
+const POW31 = 2 ** 31;
+
+// MapUtils.get31TileNumberX
+function get31TileNumberX(longitude) {
+    return Math.trunc(((longitude + 180) / 360) * POW31);
+}
+
+// MapUtils.get31TileNumberY
+function get31TileNumberY(latitude) {
+    const rad = (latitude * Math.PI) / 180;
+    const eval31 = Math.min(Math.log(Math.tan(rad) + 1 / Math.cos(rad)), Math.PI);
+
+    return Math.trunc(((1 - eval31 / Math.PI) / 2) * POW31);
+}
+
+function zigzag(v) {
+    return (v << 1) ^ (v >> 31);
+}
+
+function writeVarint(bytes, value) {
+    let v = value;
+    while ((v & ~0x7f) !== 0) {
+        bytes.push((v & 0x7f) | 0x80);
+        v >>>= 7;
+    }
+    bytes.push(v);
+}
+
+function toBase64(bytes) {
+    return Buffer.from(Uint8Array.from(bytes)).toString('base64');
+}
+
+/**
+ * Encode segments of [latitude, longitude] pairs the way the server does.
+ *
+ * @param {Array<Array<[number, number]>>} segments
+ * @returns {string} base64
+ */
+export function encodeGeometry(segments) {
+    const bytes = [];
+    writeVarint(bytes, segments.length);
+    for (const points of segments) {
+        writeVarint(bytes, points.length);
+        let px = 0;
+        let py = 0;
+        for (const [latitude, longitude] of points) {
+            const x = get31TileNumberX(longitude) >> STORE_SHIFT;
+            const y = get31TileNumberY(latitude) >> STORE_SHIFT;
+            writeVarint(bytes, zigzag(x - px));
+            writeVarint(bytes, zigzag(y - py));
+            px = x;
+            py = y;
+        }
+    }
+
+    return toBase64(bytes);
+}
+
+/** Distance in meters, enough for grid-precision assertions. */
+export function distance(lat1, lon1, lat2, lon2) {
+    const R = 6372800;
+    const toRad = (d) => (d * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+
+    return 2 * R * Math.asin(Math.sqrt(a));
+}

--- a/tests/unit/src/util/fixtures/geometry.js
+++ b/tests/unit/src/util/fixtures/geometry.js
@@ -1,5 +1,10 @@
-// Mirrors the server-side encoder net.osmand.server.osmgpx.TrackSimplifyEncoder,
-// so the decoder under test is checked against an independent implementation.
+// Test input for the geometry decoder: a copy of the server-side encoder
+// net.osmand.server.osmgpx.TrackSimplifyEncoder, so that many cases (negative deltas, multi-byte
+// varints, the edges of the mercator grid) can be generated instead of hand-writing bytes.
+//
+// This is a snapshot of the format, not a contract test: it lives in this repository, so a change
+// of the format on the server would not fail anything here. That guarantee belongs to a test on
+// TrackSimplifyEncoder itself.
 
 const STORE_ZOOM = 18;
 const STORE_SHIFT = 31 - (STORE_ZOOM + 8); // = 5

--- a/tests/unit/src/util/indexedDb.js
+++ b/tests/unit/src/util/indexedDb.js
@@ -1,0 +1,20 @@
+/** Minimal indexedDB fake: records the names of the deleted databases. */
+export function fakeIndexedDb() {
+    const deleted = [];
+    global.indexedDB = {
+        deleteDatabase: (name) => {
+            deleted.push(name);
+            const request = {};
+            // the caller assigns onsuccess after this returns, so fire it on the microtask queue
+            queueMicrotask(() => request.onsuccess?.());
+
+            return request;
+        },
+    };
+
+    return deleted;
+}
+
+export function removeIndexedDb() {
+    delete global.indexedDB;
+}


### PR DESCRIPTION
## Cover map/src/util with unit tests

Continues the unit test suite in `tests/unit` — this time the whole `map/src/util` folder.
119 new tests, 135 in total.

### Tests

| File | Covered |
|---|---|
| `01-utils.test.js` | `Utils.js`: distance and bearing, `formatMeters`, `toHHMMSS`, `quickNaNfix`, `sanitizedFileName`, `areSetsEqual`, `createUrlParams`, `encodeString`/`decodeString` round-trip, `truncateText`, `isToday`/`isYesterday` |
| `02-decode-geometry.test.js` | `decodeSimplifiedGeometry.js` |
| `03-date-fmt.test.js` | `dateFmt.js`: `localizeWeekTokens` and every `fmt` formatter |
| `04-app-data-version.test.js` | `appDataVersion.js`: version state and IndexedDB reset paths |
| `05-lang.test.js` | `lang.js` and `LanguageDisplayName.js` |
| `06-gzip.test.js` | `GzipBase64.mjs` and `GzipCompression.js` |

The geometry decoder is checked against an independent encoder that mirrors the server-side
`TrackSimplifyEncoder` (`src/util/fixtures/geometry.js`), so the two sides of the wire format
cannot drift apart unnoticed.

### Fixes found while writing the tests

- `sanitizedFileName` truncated a file name to 255 **bytes** and could cut a multi-byte character
  in half, leaving `<replacement char>` in the name. It now steps back over the UTF-8 continuation bytes,
  and returns early when the name is short enough instead of re-encoding it.
- `createUrlParams` checked `Object.keys(pretty).length` on a string. The result happened to be
  correct; the check now says what it means.

### Notes

- `GzipBase64.mjs` was stubbed in `jest.config.js` (added there only to make the `TracksManager`
  import graph load). The stub is removed — the module pulls in nothing but `pako`.
- `HttpApi.js` and `util/hooks/**` are left uncovered on purpose: the first is the network boundary
  every test already stubs, the second needs `@testing-library/react` and duplicates what the
  selenium suite checks.