### PR TITLE
Cover cloud track with unit tests

### DIFF
--- a/map/src/manager/SmartFoldersManager.js
+++ b/map/src/manager/SmartFoldersManager.js
@@ -1,5 +1,5 @@
 import { apiGet } from '../util/HttpApi';
-import { filterRegularFolders } from './track/TracksManager';
+import { filterRegularFolders, renameLastFolderSegment } from './track/TracksManager';
 import { updateSortList } from '../menu/actions/SortActions';
 import { SMART_TYPE } from '../menu/share/shareConstants';
 
@@ -80,7 +80,7 @@ export async function deleteSmartFolder(folder, ctx) {
 }
 
 export async function renameSmartFolder(folder, newName, ctx) {
-    const newFolderName = folder.fullName.replace(folder.name, newName);
+    const newFolderName = renameLastFolderSegment(folder.fullName, newName);
     const res = await apiGet(`${process.env.REACT_APP_USER_API_SITE}/mapapi/rename-smart-folder`, {
         params: {
             folderName: folder.fullName,

--- a/map/src/manager/track/DeleteTrackManager.js
+++ b/map/src/manager/track/DeleteTrackManager.js
@@ -278,22 +278,23 @@ function deleteTracksFromGroups(trackName, ctx) {
         const pathToGroup = parts.slice(0, -1).join('/');
         const group = findGroupByName(ctx.tracksGroups, pathToGroup);
         if (group) {
-            const fileWithoutGroup = parts[parts.length - 1];
-            const fileIndexInGroupFiles = group.groupFiles.findIndex((file) => file.name === fileWithoutGroup);
+            const fileIndexInGroupFiles = group.groupFiles.findIndex((file) => file.name === trackName);
             if (fileIndexInGroupFiles !== -1) {
                 group.groupFiles.splice(fileIndexInGroupFiles, 1);
                 group.realSize--;
             }
-            const fileIndexInFiles = group.files.findIndex((file) => file.name === fileWithoutGroup);
+            const fileIndexInFiles = group.files.findIndex((file) => file.name === trackName);
             if (fileIndexInFiles !== -1) {
                 group.files.splice(fileIndexInFiles, 1);
             }
         }
     } else {
         const group = findGroupByName(ctx.tracksGroups, '');
-        const fileIndexInFiles = group.files.findIndex((file) => file.name === trackName);
-        if (fileIndexInFiles !== -1) {
-            group.files.splice(fileIndexInFiles, 1);
+        if (group) {
+            const fileIndexInFiles = group.files.findIndex((file) => file.name === trackName);
+            if (fileIndexInFiles !== -1) {
+                group.files.splice(fileIndexInFiles, 1);
+            }
         }
     }
     ctx.setTracksGroups([...ctx.tracksGroups]);

--- a/map/src/manager/track/DeleteTrackManager.js
+++ b/map/src/manager/track/DeleteTrackManager.js
@@ -2,7 +2,7 @@ import { isCloudTrack, isLocalTrack, OBJECT_TYPE_FAVORITE } from '../../context/
 import { loadShareFiles } from '../../util/hooks/useInitialFilesLoad';
 import { loadSmartFolders } from '../SmartFoldersManager';
 import { apiGet, apiPost } from '../../util/HttpApi';
-import { findGroupByName, getAllVisibleFiles, openTrackOnMap } from './TracksManager';
+import { calculateLastModified, getAllVisibleFiles, openTrackOnMap } from './TracksManager';
 import { refreshGlobalFiles } from './SaveTrackManager';
 import { FAVORITE_FILE_TYPE } from '../FavoritesManager';
 import isEmpty from 'lodash-es/isEmpty';
@@ -272,31 +272,31 @@ export async function showAllVisibleTracks(ctx) {
     ctx.setGpxLoading(false);
 }
 
-function deleteTracksFromGroups(trackName, ctx) {
-    const parts = trackName.split('/');
-    if (parts.length > 1) {
-        const pathToGroup = parts.slice(0, -1).join('/');
-        const group = findGroupByName(ctx.tracksGroups, pathToGroup);
-        if (group) {
-            const fileIndexInGroupFiles = group.groupFiles.findIndex((file) => file.name === trackName);
-            if (fileIndexInGroupFiles !== -1) {
-                group.groupFiles.splice(fileIndexInGroupFiles, 1);
-                group.realSize--;
-            }
-            const fileIndexInFiles = group.files.findIndex((file) => file.name === trackName);
-            if (fileIndexInFiles !== -1) {
-                group.files.splice(fileIndexInFiles, 1);
-            }
-        }
-    } else {
-        const group = findGroupByName(ctx.tracksGroups, '');
-        if (group) {
-            const fileIndexInFiles = group.files.findIndex((file) => file.name === trackName);
-            if (fileIndexInFiles !== -1) {
-                group.files.splice(fileIndexInFiles, 1);
-            }
-        }
+function removeTrackByName(files, trackName) {
+    const index = files?.findIndex((file) => file.name === trackName) ?? -1;
+    if (index === -1) {
+        return false;
     }
+    files.splice(index, 1);
+
+    return true;
+}
+
+// the track is listed in the group that owns it and in the files of every group above it
+function removeTrackFromGroups(groups, trackName) {
+    groups?.forEach((group) => {
+        removeTrackFromGroups(group.subfolders, trackName);
+        const removedFromGroupFiles = removeTrackByName(group.groupFiles, trackName);
+        const removedFromFiles = removeTrackByName(group.files, trackName);
+        if (removedFromGroupFiles || removedFromFiles) {
+            group.realSize = Math.max(0, (group.realSize ?? 0) - 1);
+            calculateLastModified(group);
+        }
+    });
+}
+
+function deleteTracksFromGroups(trackName, ctx) {
+    removeTrackFromGroups(ctx.tracksGroups, trackName);
     ctx.setTracksGroups([...ctx.tracksGroups]);
 }
 

--- a/map/src/manager/track/SaveTrackManager.js
+++ b/map/src/manager/track/SaveTrackManager.js
@@ -18,6 +18,7 @@ import TracksManager, {
     prepareName,
     renameLastFolderSegment,
     updateMetadata,
+    calculateLastModified,
 } from './TracksManager';
 import { syncCloudTrackInfo, findInfoFile } from './TrackAppearanceManager';
 import isEmpty from 'lodash-es/isEmpty';
@@ -461,31 +462,19 @@ function updateTrackGroups(listFiles, ctx) {
 }
 
 function updateUpdatetimemsInGroups(groups, fileName, newUpdatetimems) {
-    return groups.map((group) => {
-        if (group.subfolders.length > 0) {
-            const updatedSubfolders = updateUpdatetimemsInGroups(group.subfolders, fileName, newUpdatetimems);
+    const updateFile = (file) =>
+        file.name === fileName ? { ...file, updatetimems: newUpdatetimems, updatetime: newUpdatetimems } : file;
 
-            return {
-                ...group,
-                subfolders: updatedSubfolders,
-                groupFiles: group.groupFiles.map((file) =>
-                    file.name === fileName ? { ...file, updatetimems: newUpdatetimems } : file
-                ),
-                files: group.files.map((file) =>
-                    file.name === fileName ? { ...file, updatetimems: newUpdatetimems } : file
-                ),
-            };
-        } else {
-            return {
-                ...group,
-                groupFiles: group.groupFiles.map((file) =>
-                    file.name === fileName ? { ...file, updatetimems: newUpdatetimems } : file
-                ),
-                files: group.files.map((file) =>
-                    file.name === fileName ? { ...file, updatetimems: newUpdatetimems } : file
-                ),
-            };
-        }
+    return groups.map((group) => {
+        const updatedGroup = {
+            ...group,
+            subfolders: updateUpdatetimemsInGroups(group.subfolders, fileName, newUpdatetimems),
+            groupFiles: group.groupFiles.map(updateFile),
+            files: group.files.map(updateFile),
+        };
+        calculateLastModified(updatedGroup);
+
+        return updatedGroup;
     });
 }
 

--- a/map/src/manager/track/SaveTrackManager.js
+++ b/map/src/manager/track/SaveTrackManager.js
@@ -16,6 +16,7 @@ import TracksManager, {
     GPX_FILE_EXT,
     KMZ_FILE_EXT,
     prepareName,
+    renameLastFolderSegment,
     updateMetadata,
 } from './TracksManager';
 import { syncCloudTrackInfo, findInfoFile } from './TrackAppearanceManager';
@@ -327,7 +328,7 @@ export async function duplicateTrack(oldName, folderName, newName, ctx) {
 }
 
 export async function renameFolder(folder, newName, ctx) {
-    const newFolderName = folder.fullName.replace(folder.name, newName);
+    const newFolderName = renameLastFolderSegment(folder.fullName, newName);
     const res = await apiGet(`${process.env.REACT_APP_USER_API_SITE}/mapapi/rename-folder`, {
         params: {
             folderName: folder.fullName,

--- a/map/src/manager/track/TrackAppearanceManager.js
+++ b/map/src/manager/track/TrackAppearanceManager.js
@@ -144,6 +144,11 @@ export function updateGroupsVisibility(ctx, groupNames, hidden, debouncerTimer) 
         }
 
         if (isCloudTrack(ctx)) {
+            ctx.mutateGpxFiles((files) => {
+                if (files[updatedGpxFile.name]) {
+                    files[updatedGpxFile.name].info = updatedGpxFile.info;
+                }
+            });
             const infoFile = findInfoFile(ctx, updatedGpxFile.name);
             if (debouncerTimer.current) {
                 clearTimeout(debouncerTimer.current);

--- a/map/src/manager/track/TracksManager.js
+++ b/map/src/manager/track/TracksManager.js
@@ -701,7 +701,7 @@ function addFilesAndCalculateLastModified(groups) {
     });
 }
 
-function calculateLastModified(group) {
+export function calculateLastModified(group) {
     if (group.type === SMART_TYPE) {
         return;
     }

--- a/map/src/manager/track/TracksManager.js
+++ b/map/src/manager/track/TracksManager.js
@@ -143,6 +143,13 @@ export function removeGpxExtension(name) {
     return name.replace(/\.gpx$/i, '');
 }
 
+export function renameLastFolderSegment(fullName, newName) {
+    const parts = fullName.split('/');
+    parts[parts.length - 1] = newName;
+
+    return parts.join('/');
+}
+
 export function prepareName(name, local = false) {
     if (typeof name !== 'string') {
         return '';

--- a/map/src/manager/track/TracksManager.js
+++ b/map/src/manager/track/TracksManager.js
@@ -679,7 +679,13 @@ function addFilesAndCalculateLastModified(groups) {
                 );
             });
 
-            group.files.push(...group.subfolders.reduce((acc, subfolder) => acc.concat(subfolder.files), []));
+            group.subfolders.forEach((subfolder) => {
+                subfolder.files.forEach((file) => {
+                    if (!group.files.some((groupFile) => groupFile.name === file.name)) {
+                        group.files.push(file);
+                    }
+                });
+            });
         }
         group.groupFiles.forEach((file) => {
             if (!group.files.some((groupFile) => groupFile.name === file.name)) {

--- a/map/src/manager/track/TracksManager.js
+++ b/map/src/manager/track/TracksManager.js
@@ -652,7 +652,8 @@ export function createTrackGroups({ files, isSmartf = false, ctx }) {
         groups: trackGroups,
     });
 
-    return sorted.groups;
+    // doSort returns nothing when there is nothing to sort, but the callers expect a list
+    return sorted.groups ?? [];
 }
 
 function addFilesAndCalculateLastModified(groups) {

--- a/map/src/menu/visibletracks/VisibleTracks.jsx
+++ b/map/src/menu/visibletracks/VisibleTracks.jsx
@@ -14,7 +14,6 @@ import { hideAllTracks, showAllVisibleTracks } from '../../manager/track/DeleteT
 import { useTranslation } from 'react-i18next';
 import { SHARE_TYPE } from '../share/shareConstants';
 import { useRecentDataSaver } from '../../util/hooks/menu/useRecentDataSaver';
-import LoginContext from '../../context/LoginContext';
 import Loading from '../errors/Loading';
 import {
     CONFIGURE_URL,
@@ -34,18 +33,22 @@ export function getCountVisibleTracks(visibleTracks) {
     return visibleTracks?.new?.length || 0;
 }
 
+// shared files are always kept in the visible cache with the SHARE_TYPE prefix
+function visibleCacheName(file, shared) {
+    return shared ? VISIBLE_SHARE_MARKER + file.name : file.name;
+}
+
 export function isVisibleTrack(file) {
-    let savedVisible = JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
-    return !!savedVisible?.open?.includes(file.name);
+    const savedVisible = JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
+    return !!savedVisible?.open?.includes(visibleCacheName(file, file.sharedWithMe));
 }
 
 export function updateVisibleCache({ visible, file, smartf = null }) {
-    let savedVisible = JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
-    if (savedVisible && !savedVisible.open) {
+    const savedVisible = JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG)) ?? { old: [], new: [] };
+    if (!savedVisible.open) {
         savedVisible.open = [];
     }
-    // always mark shared files in visible cache with SHARE_TYPE prefix
-    const fileName = smartf?.type === SHARE_TYPE ? VISIBLE_SHARE_MARKER + file.name : file.name;
+    const fileName = visibleCacheName(file, smartf?.type === SHARE_TYPE);
 
     if (visible) {
         savedVisible.open.push(fileName);
@@ -60,17 +63,19 @@ export function updateVisibleCache({ visible, file, smartf = null }) {
 
 export function hideAllVisTracks() {
     const savedVisible = JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
-    if (savedVisible) {
-        savedVisible.open = [];
+    if (!savedVisible) {
+        return;
     }
+    savedVisible.open = [];
     localStorage.setItem(TRACK_VISIBLE_FLAG, JSON.stringify(savedVisible));
 }
 
 export function showAllVisTracks() {
     const savedVisible = JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
-    if (savedVisible) {
-        savedVisible.open = [...(savedVisible.old || []), ...(savedVisible.new || [])];
+    if (!savedVisible) {
+        return;
     }
+    savedVisible.open = [...(savedVisible.old || []), ...(savedVisible.new || [])];
     localStorage.setItem(TRACK_VISIBLE_FLAG, JSON.stringify(savedVisible));
 }
 
@@ -91,8 +96,8 @@ export function addCloseTracksToRecently(ctx) {
         ctx.visibleTracks.new?.forEach((t) => {
             const sharedFile = t.sharedWithMe;
 
-            const fileName = sharedFile ? VISIBLE_SHARE_MARKER + t.name : t.name;
-            if (savedVisible.open && savedVisible.open.includes(fileName)) {
+            const fileName = visibleCacheName(t, sharedFile);
+            if (savedVisible.open?.includes(fileName)) {
                 newVisFiles.new.push(t);
                 newVisFilesNames.new.push(fileName);
                 newVisFilesNames.open.push(fileName);

--- a/map/src/util/hooks/useInitialFilesLoad.js
+++ b/map/src/util/hooks/useInitialFilesLoad.js
@@ -29,8 +29,8 @@ export function applyRefreshedInfoFilesToGpx(updatedData, setGpxFiles, setSelect
         let next = null;
         for (const [gpxName, file] of Object.entries(prev)) {
             const infoRow = infoFilesFromRefresh.find((r) => r.name === gpxName + INFO_FILE_EXT);
-            if (!infoRow) continue;
-            const data = infoRow.details?.data ?? {};
+            const data = infoRow?.details?.data;
+            if (data == null) continue;
             next = next ?? { ...prev };
             next[gpxName] = {
                 ...file,

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -36,6 +36,8 @@ module.exports = {
         'context/AppContext$': `${STUBS}/appContext.js`,
         // modules pulling map layers / routing / i18n - not exercised by unit tests
         '^leaflet$': `${STUBS}/empty.js`,
+        // sorting is plain logic that createTrackGroups depends on, keep it real
+        'menu/actions/SortActions$': path.join(MAP_DIR, 'src/menu/actions/SortActions.jsx'),
         // UI layers - unit tests cover managers, not components
         '/(menu|frame|infoblock|dialogs)/': `${STUBS}/empty.js`,
         '/map/(layers|util|markers)/': `${STUBS}/empty.js`,

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -38,6 +38,8 @@ module.exports = {
         '^leaflet$': `${STUBS}/empty.js`,
         // sorting is plain logic that createTrackGroups depends on, keep it real
         'menu/actions/SortActions$': path.join(MAP_DIR, 'src/menu/actions/SortActions.jsx'),
+        // the visible-tracks cache is plain localStorage logic used by the managers
+        'visibletracks/VisibleTracks$': path.join(MAP_DIR, 'src/menu/visibletracks/VisibleTracks.jsx'),
         // plain constants shared by the managers
         'menu/share/shareConstants$': path.join(MAP_DIR, 'src/menu/share/shareConstants.js'),
         // UI layers - unit tests cover managers, not components

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -38,6 +38,8 @@ module.exports = {
         '^leaflet$': `${STUBS}/empty.js`,
         // sorting is plain logic that createTrackGroups depends on, keep it real
         'menu/actions/SortActions$': path.join(MAP_DIR, 'src/menu/actions/SortActions.jsx'),
+        // plain constants shared by the managers
+        'menu/share/shareConstants$': path.join(MAP_DIR, 'src/menu/share/shareConstants.js'),
         // UI layers - unit tests cover managers, not components
         '/(menu|frame|infoblock|dialogs)/': `${STUBS}/empty.js`,
         '/map/(layers|util|markers)/': `${STUBS}/empty.js`,
@@ -45,7 +47,6 @@ module.exports = {
         MarkerOptions$: `${STUBS}/empty.js`,
         'geoRouter(\\.js)?$': `${STUBS}/empty.js`,
         '/i18n$': `${STUBS}/empty.js`,
-        useInitialFilesLoad$: `${STUBS}/empty.js`,
         // app sources
         '^@map/(.*)$': path.join(MAP_DIR, 'src/$1'),
     },

--- a/tests/unit/src/tests/tracks/01-cloud-info-file.test.js
+++ b/tests/unit/src/tests/tracks/01-cloud-info-file.test.js
@@ -109,3 +109,29 @@ test('local track: group hidden before the upload keeps the cloud path', async (
     expect(info.file).toBe('/tracks/Folder/Track.gpx');
     expect(info.pointsGroups[WPT_GROUP].hidden).toBe(true);
 });
+
+describe('cloud track: hiding a waypoint group', () => {
+    function cloudCtx() {
+        const ctx = createCtx({ track: createTrack({ name: CLOUD_TRACK_NAME }) });
+        ctx.gpxFiles = { [CLOUD_TRACK_NAME]: { name: CLOUD_TRACK_NAME, info: { pointsGroups: {} } } };
+        return ctx;
+    }
+
+    test('the loaded track is updated at once, the map layer is rebuilt from it', () => {
+        const ctx = cloudCtx();
+
+        updateGroupsVisibility(ctx, [WPT_GROUP], true, { current: null });
+
+        expect(ctx.gpxFiles[CLOUD_TRACK_NAME].info.pointsGroups[WPT_GROUP].hidden).toBe(true);
+        expect(ctx.selectedGpxFile.info.pointsGroups[WPT_GROUP].hidden).toBe(true);
+    });
+
+    test('a track that is not loaded on the map is skipped', () => {
+        const ctx = cloudCtx();
+        ctx.gpxFiles = {};
+
+        updateGroupsVisibility(ctx, [WPT_GROUP], true, { current: null });
+
+        expect(ctx.gpxFiles).toEqual({});
+    });
+});

--- a/tests/unit/src/tests/tracks/04-track-groups.test.js
+++ b/tests/unit/src/tests/tracks/04-track-groups.test.js
@@ -51,6 +51,13 @@ describe('createTrackGroups', () => {
         expect(folder.subfolders[0].realSize).toBe(1);
     });
 
+    test('a file of a nested folder is listed once in every group above it', () => {
+        const groups = build([file('Root.gpx'), file('Folder/Nested/Deep.gpx')]);
+
+        expect(findGroupByName(groups, 'Folder').files.map((f) => f.name)).toEqual(['Folder/Nested/Deep.gpx']);
+        expect(findGroupByName(groups, '').files.map((f) => f.name)).toEqual(['Root.gpx', 'Folder/Nested/Deep.gpx']);
+    });
+
     test('folders and loose files live together', () => {
         const groups = build([file('Track.gpx'), file('Folder/Inside.gpx')]);
 

--- a/tests/unit/src/tests/tracks/04-track-groups.test.js
+++ b/tests/unit/src/tests/tracks/04-track-groups.test.js
@@ -1,0 +1,109 @@
+import { EMPTY_FILE_NAME, createTrackGroups, findGroupByName } from '@map/manager/track/TracksManager';
+
+// sorting is not the subject here: without ctx.selectedSort doSort returns the groups as they are
+const CTX = { tracksGroups: [] };
+
+function file(name, updatetimems = 1000) {
+    return { name, updatetimems, updatetime: new Date(updatetimems).toISOString() };
+}
+
+function build(files) {
+    return createTrackGroups({ files, ctx: CTX });
+}
+
+describe('createTrackGroups', () => {
+    test('files without a folder go to the default group', () => {
+        const groups = build([file('Track.gpx'), file('Second.gpx')]);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0].name).toBe('');
+        expect(groups[0].files.map((f) => f.name)).toEqual(['Track.gpx', 'Second.gpx']);
+        expect(groups[0].realSize).toBe(2);
+    });
+
+    test('a folder becomes a group with its full path', () => {
+        const groups = build([file('Folder/Track.gpx')]);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0].name).toBe('Folder');
+        expect(groups[0].fullName).toBe('Folder');
+        expect(groups[0].groupFiles.map((f) => f.name)).toEqual(['Folder/Track.gpx']);
+        expect(groups[0].subfolders).toEqual([]);
+    });
+
+    test('nested folders become subfolders', () => {
+        const groups = build([file('Folder/Nested/Deep.gpx')]);
+
+        const folder = groups[0];
+        expect(folder.fullName).toBe('Folder');
+        expect(folder.subfolders).toHaveLength(1);
+        expect(folder.subfolders[0].fullName).toBe('Folder/Nested');
+    });
+
+    test('a file of a subfolder is not counted twice in the parent', () => {
+        const groups = build([file('Folder/Own.gpx'), file('Folder/Nested/Deep.gpx')]);
+
+        const folder = groups[0];
+        // groupFiles are the files of the folder itself, files are everything below it
+        expect(folder.groupFiles.map((f) => f.name)).toEqual(['Folder/Own.gpx']);
+        expect(folder.files.map((f) => f.name).sort()).toEqual(['Folder/Nested/Deep.gpx', 'Folder/Own.gpx']);
+        expect(folder.realSize).toBe(2);
+        expect(folder.subfolders[0].realSize).toBe(1);
+    });
+
+    test('folders and loose files live together', () => {
+        const groups = build([file('Track.gpx'), file('Folder/Inside.gpx')]);
+
+        const names = groups.map((g) => g.fullName);
+        expect(names).toContain('Folder');
+        expect(names).toContain('');
+        const defaultGroup = groups.find((g) => g.fullName === '');
+        // the default group adopts the folders, so its files hold everything
+        expect(defaultGroup.groupFiles.map((f) => f.name)).toEqual(['Track.gpx']);
+        expect(defaultGroup.subfolders.map((g) => g.fullName)).toEqual(['Folder']);
+        expect(defaultGroup.files.map((f) => f.name).sort()).toEqual(['Folder/Inside.gpx', 'Track.gpx']);
+    });
+
+    test('the last modified time is the newest file below the folder', () => {
+        const groups = build([file('Folder/Old.gpx', 1000), file('Folder/Nested/New.gpx', 5000)]);
+
+        const folder = groups[0];
+        expect(folder.lastModifiedMs).toBe(5000);
+        expect(folder.lastModifiedDate).toBe(new Date(5000).toISOString());
+        expect(folder.subfolders[0].lastModifiedMs).toBe(5000);
+    });
+
+    test('an empty folder placeholder is not a track', () => {
+        const placeholder = { name: 'Folder/' + EMPTY_FILE_NAME, filesize: 0, updatetimems: 1000 };
+        const groups = build([placeholder, file('Folder/Track.gpx')]);
+
+        expect(groups[0].groupFiles).toHaveLength(2);
+        expect(groups[0].realSize).toBe(1);
+    });
+
+    test('no files at all is an empty list, not a missing one', () => {
+        expect(build([])).toEqual([]);
+    });
+});
+
+describe('findGroupByName', () => {
+    const GROUPS = build([file('Folder/Track.gpx'), file('Folder/Nested/Deep.gpx'), file('Other/Track.gpx')]);
+
+    test('a top level folder', () => {
+        expect(findGroupByName(GROUPS, 'Folder').fullName).toBe('Folder');
+        expect(findGroupByName(GROUPS, 'Other').fullName).toBe('Other');
+    });
+
+    test('a nested folder by its full path', () => {
+        expect(findGroupByName(GROUPS, 'Folder/Nested').fullName).toBe('Folder/Nested');
+    });
+
+    test('the short name of a nested folder is not a path', () => {
+        expect(findGroupByName(GROUPS, 'Nested')).toBeNull();
+    });
+
+    test('an unknown folder', () => {
+        expect(findGroupByName(GROUPS, 'Missing')).toBeNull();
+        expect(findGroupByName([], 'Folder')).toBeNull();
+    });
+});

--- a/tests/unit/src/tests/tracks/05-rename-track.test.js
+++ b/tests/unit/src/tests/tracks/05-rename-track.test.js
@@ -1,0 +1,153 @@
+import { TRACK_VISIBLE_FLAG } from '@map/manager/track/TracksManager';
+import {
+    duplicateTrack,
+    renameFolder,
+    renameTrack,
+    saveEmptyTrack,
+    updateVisibleTracks,
+} from '@map/manager/track/SaveTrackManager';
+import { apiGet, apiPost } from '@map/util/HttpApi';
+import { findRequest } from '../../util/requests';
+import { createCtx } from '../../util/fixtures/tracks';
+
+const CLOUD_FILES = [{ name: 'Folder/Track.gpx', type: 'GPX', updatetimems: 1000 }];
+
+function cloudCtx() {
+    return createCtx({ uniqueFiles: CLOUD_FILES });
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    // rename-file and rename-folder answer ok, list-files gives the refreshed list
+    apiGet.mockImplementation(async (url) => {
+        if (url.endsWith('/mapapi/list-files')) {
+            return { json: async () => ({ uniqueFiles: CLOUD_FILES }) };
+        }
+
+        return { data: { status: 'ok' } };
+    });
+    apiPost.mockResolvedValue({ data: { status: 'ok' } });
+});
+
+describe('renameTrack', () => {
+    test('the new name keeps the folder and the extension', async () => {
+        await renameTrack('Folder/Old.gpx', 'Folder/', 'New', cloudCtx());
+
+        const { options } = findRequest(apiGet, '/mapapi/rename-file');
+        expect(options.params).toEqual({
+            oldName: 'Folder/Old.gpx',
+            newName: 'Folder/New.gpx',
+            type: 'GPX',
+            saveCopy: false,
+        });
+    });
+
+    test('the same name sends nothing', async () => {
+        await renameTrack('Folder/Track.gpx', 'Folder/', 'Track', cloudCtx());
+
+        expect(apiGet).not.toHaveBeenCalled();
+    });
+
+    test('a server error is shown and the list is not refreshed', async () => {
+        apiGet.mockResolvedValue({ data: 'name is occupied' });
+        const ctx = cloudCtx();
+
+        await renameTrack('Folder/Old.gpx', 'Folder/', 'New', ctx);
+
+        expect(ctx.setTrackErrorMsg).toHaveBeenCalledWith({ title: 'Rename error', msg: 'name is occupied' });
+        expect(apiGet).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('renameFolder', () => {
+    test('only the folder itself is renamed, the path is kept', async () => {
+        await renameFolder({ name: 'Nested', fullName: 'Folder/Nested' }, 'Renamed', cloudCtx());
+
+        const { options } = findRequest(apiGet, '/mapapi/rename-folder');
+        expect(options.params).toEqual({
+            folderName: 'Folder/Nested',
+            newFolderName: 'Folder/Renamed',
+            type: 'GPX',
+        });
+    });
+
+    test('the name of the parent folder is not touched when it contains the same words', async () => {
+        await renameFolder({ name: 'Bike', fullName: 'Bike rides/Bike' }, 'MTB', cloudCtx());
+
+        const { options } = findRequest(apiGet, '/mapapi/rename-folder');
+        expect(options.params.newFolderName).toBe('Bike rides/MTB');
+    });
+});
+
+describe('duplicateTrack', () => {
+    test('a copy is saved next to the original, under a free name', async () => {
+        const ctx = cloudCtx();
+        ctx.tracksGroups = [{ name: 'Folder', fullName: 'Folder', groupFiles: CLOUD_FILES, subfolders: [] }];
+
+        await duplicateTrack('Folder/Track.gpx', 'Folder', 'Track', ctx);
+
+        const { options } = findRequest(apiGet, '/mapapi/rename-file');
+        expect(options.params).toEqual({
+            oldName: 'Folder/Track.gpx',
+            newName: 'Folder/Track - 1.gpx',
+            type: 'GPX',
+            saveCopy: true,
+        });
+    });
+});
+
+describe('saveEmptyTrack', () => {
+    test('a folder is created as a placeholder file', async () => {
+        await expect(saveEmptyTrack('New folder', cloudCtx())).resolves.toBe(true);
+
+        const { options } = findRequest(apiPost, '/mapapi/upload-file');
+        expect(options.params).toEqual({ type: 'GPX', name: 'New folder/__folder__.info' });
+    });
+});
+
+describe('updateVisibleTracks', () => {
+    function visible(state) {
+        localStorage.setItem(TRACK_VISIBLE_FLAG, JSON.stringify(state));
+    }
+
+    function stored() {
+        return JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
+    }
+
+    test('a visible track keeps being visible under the new name', () => {
+        visible({ new: ['Folder/Old.gpx'], old: [], open: [] });
+
+        updateVisibleTracks('Folder/Old.gpx', 'Folder/New.gpx');
+
+        expect(stored().new).toEqual(['Folder/New.gpx']);
+    });
+
+    test('a track of the previous session is renamed as well', () => {
+        visible({ new: [], old: ['Folder/Old.gpx'], open: [] });
+
+        updateVisibleTracks('Folder/Old.gpx', 'Folder/New.gpx');
+
+        expect(stored().old).toEqual(['Folder/New.gpx']);
+    });
+
+    test('an opened track is renamed as well', () => {
+        visible({ new: ['Folder/Old.gpx'], old: [], open: ['Folder/Old.gpx'] });
+
+        updateVisibleTracks('Folder/Old.gpx', 'Folder/New.gpx');
+
+        expect(stored().open).toEqual(['Folder/New.gpx']);
+    });
+
+    test('other tracks are left alone', () => {
+        visible({ new: ['Folder/Other.gpx'], old: ['Folder/Third.gpx'], open: [] });
+
+        updateVisibleTracks('Folder/Old.gpx', 'Folder/New.gpx');
+
+        expect(stored()).toEqual({ new: ['Folder/Other.gpx'], old: ['Folder/Third.gpx'], open: [] });
+    });
+
+    test('nothing stored - nothing to do', () => {
+        expect(() => updateVisibleTracks('Folder/Old.gpx', 'Folder/New.gpx')).not.toThrow();
+        expect(localStorage.getItem(TRACK_VISIBLE_FLAG)).toBeNull();
+    });
+});

--- a/tests/unit/src/tests/tracks/06-delete-track.test.js
+++ b/tests/unit/src/tests/tracks/06-delete-track.test.js
@@ -1,0 +1,170 @@
+import { deleteTrack, deleteTrackFolder, deleteTracksFromMap } from '@map/manager/track/DeleteTrackManager';
+import { apiGet, apiPost } from '@map/util/HttpApi';
+import { findRequest } from '../../util/requests';
+import { createTrackGroups, findGroupByName } from '@map/manager/track/TracksManager';
+import { createCtx } from '../../util/fixtures/tracks';
+
+const LOGGED_IN = { loginUser: 'osmand@grr.la' };
+
+function cloudCtx() {
+    return createCtx({ uniqueFiles: [{ name: 'Folder/Track.gpx', type: 'GPX' }] });
+}
+
+beforeEach(() => {
+    apiPost.mockResolvedValue({ status: 200 });
+    apiGet.mockImplementation(async (url) => {
+        if (url.endsWith('/mapapi/list-files')) {
+            return { json: async () => ({ uniqueFiles: [] }) };
+        }
+        if (url.endsWith('/mapapi/get-smart-folders')) {
+            return { data: [] };
+        }
+
+        return { data: { status: 'ok' } };
+    });
+});
+
+describe('deleteTrack', () => {
+    test('the file is deleted in the cloud and dropped from the list', async () => {
+        const ctx = cloudCtx();
+
+        await deleteTrack({ file: { name: 'Folder/Track.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const { options } = findRequest(apiPost, '/mapapi/delete-file');
+        expect(options.params).toEqual({ name: 'Folder/Track.gpx', type: 'GPX' });
+        expect(ctx.listFiles.uniqueFiles).toEqual([]);
+    });
+
+    test('the open track is marked for removal on the map', async () => {
+        const ctx = cloudCtx();
+
+        await deleteTrack({ file: { name: 'Folder/Track.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const mutate = ctx.mutateGpxFiles.mock.calls[0][0];
+        const files = { 'Folder/Track.gpx': { url: 'http://track' } };
+        mutate(files);
+        expect(files['Folder/Track.gpx']).toEqual({ url: null, delete: true });
+    });
+
+    test('nothing happens without a logged in user', async () => {
+        await deleteTrack({ file: { name: 'Folder/Track.gpx' }, ctx: cloudCtx(), ltx: {} });
+
+        expect(apiPost).not.toHaveBeenCalled();
+    });
+
+    test('a nameless track is not deleted', async () => {
+        const ctx = cloudCtx();
+        ctx.selectedGpxFile = {};
+
+        await deleteTrack({ file: null, ctx, ltx: LOGGED_IN });
+
+        expect(apiPost).not.toHaveBeenCalled();
+    });
+});
+
+describe('deleteTrack: track groups', () => {
+    function ctxWithGroups(names) {
+        const files = names.map((name) => ({ name, updatetimems: 1000 }));
+        const ctx = createCtx({ uniqueFiles: files });
+        ctx.tracksGroups = createTrackGroups({ files, ctx });
+        return ctx;
+    }
+
+    test('a track of a folder is removed from that folder', async () => {
+        const ctx = ctxWithGroups(['Folder/Track.gpx', 'Folder/Second.gpx']);
+
+        await deleteTrack({ file: { name: 'Folder/Track.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const folder = findGroupByName(ctx.tracksGroups, 'Folder');
+        expect(folder.groupFiles.map((f) => f.name)).toEqual(['Folder/Second.gpx']);
+        expect(folder.files.map((f) => f.name)).toEqual(['Folder/Second.gpx']);
+        expect(folder.realSize).toBe(1);
+    });
+
+    test('a track of a subfolder is removed from that subfolder', async () => {
+        const ctx = ctxWithGroups(['Folder/Nested/Deep.gpx', 'Folder/Own.gpx']);
+
+        await deleteTrack({ file: { name: 'Folder/Nested/Deep.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const nested = findGroupByName(ctx.tracksGroups, 'Folder/Nested');
+        expect(nested.groupFiles).toEqual([]);
+        expect(nested.realSize).toBe(0);
+    });
+
+    test('a track without a folder is removed from the default group', async () => {
+        const ctx = ctxWithGroups(['Track.gpx', 'Second.gpx']);
+
+        await deleteTrack({ file: { name: 'Track.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const defaultGroup = findGroupByName(ctx.tracksGroups, '');
+        expect(defaultGroup.files.map((f) => f.name)).toEqual(['Second.gpx']);
+    });
+
+    test('a track is deleted even when the groups are not loaded yet', async () => {
+        const ctx = createCtx({ uniqueFiles: [{ name: 'Track.gpx' }] });
+
+        await deleteTrack({ file: { name: 'Track.gpx' }, ctx, ltx: LOGGED_IN });
+
+        expect(ctx.listFiles.uniqueFiles).toEqual([]);
+    });
+});
+
+describe('deleteTrackFolder', () => {
+    test('the folder is deleted by its full path', async () => {
+        await deleteTrackFolder({ fullName: 'Folder/Nested' }, cloudCtx());
+
+        const { options } = findRequest(apiGet, '/mapapi/delete-folder');
+        expect(options.params).toEqual({ folderName: 'Folder/Nested', type: 'GPX' });
+    });
+
+    test('a server error is shown', async () => {
+        apiGet.mockImplementation(async () => ({ data: 'folder is not empty' }));
+        const ctx = cloudCtx();
+
+        await deleteTrackFolder({ fullName: 'Folder' }, ctx);
+
+        expect(ctx.setTrackErrorMsg).toHaveBeenCalledWith({ title: 'Delete error', msg: 'folder is not empty' });
+    });
+});
+
+describe('deleteTracksFromMap', () => {
+    test('only tracks shown on the map are hidden', () => {
+        const ctx = cloudCtx();
+        const shown = { name: 'Shown.gpx', url: 'http://shown' };
+
+        deleteTracksFromMap(ctx, [shown, { name: 'Hidden.gpx' }]);
+
+        const update = ctx.setGpxFiles.mock.calls[0][0];
+        const next = update({ 'Shown.gpx': { url: 'http://shown' }, 'Hidden.gpx': { url: null } });
+        expect(next['Shown.gpx'].url).toBeNull();
+        expect(next['Hidden.gpx'].url).toBeNull();
+    });
+
+    test('shared tracks are hidden in their own storage', () => {
+        const ctx = cloudCtx();
+
+        deleteTracksFromMap(ctx, [{ name: 'Shared.gpx', url: 'http://shared', sharedWithMe: true }]);
+
+        expect(ctx.setGpxFiles).not.toHaveBeenCalled();
+        const update = ctx.setShareWithMeFiles.mock.calls[0][0];
+        const next = update({ tracks: { 'Shared.gpx': { url: 'http://shared' } } });
+        expect(next.tracks['Shared.gpx'].url).toBeNull();
+    });
+
+    test('the open track stops being the selected object', () => {
+        const ctx = cloudCtx();
+        ctx.selectedGpxFile = { name: 'Shown.gpx' };
+
+        deleteTracksFromMap(ctx, [{ name: 'Shown.gpx', url: 'http://shown' }]);
+
+        expect(ctx.setCurrentObjectType).toHaveBeenCalledWith(null);
+    });
+
+    test('nothing to hide', () => {
+        const ctx = cloudCtx();
+
+        deleteTracksFromMap(ctx, []);
+
+        expect(ctx.setGpxFiles).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/src/tests/tracks/06-delete-track.test.js
+++ b/tests/unit/src/tests/tracks/06-delete-track.test.js
@@ -63,8 +63,8 @@ describe('deleteTrack', () => {
 });
 
 describe('deleteTrack: track groups', () => {
-    function ctxWithGroups(names) {
-        const files = names.map((name) => ({ name, updatetimems: 1000 }));
+    function ctxWithGroups(names, updatetimems = () => 1000) {
+        const files = names.map((name) => ({ name, updatetimems: updatetimems(name) }));
         const ctx = createCtx({ uniqueFiles: files });
         ctx.tracksGroups = createTrackGroups({ files, ctx });
         return ctx;
@@ -98,6 +98,40 @@ describe('deleteTrack: track groups', () => {
 
         const defaultGroup = findGroupByName(ctx.tracksGroups, '');
         expect(defaultGroup.files.map((f) => f.name)).toEqual(['Second.gpx']);
+    });
+
+    test('a root track is removed from the default group that owns folders', async () => {
+        const ctx = ctxWithGroups(['Track.gpx', 'Folder/Inside.gpx']);
+
+        await deleteTrack({ file: { name: 'Track.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const defaultGroup = findGroupByName(ctx.tracksGroups, '');
+        expect(defaultGroup.groupFiles).toEqual([]);
+        expect(defaultGroup.files.map((f) => f.name)).toEqual(['Folder/Inside.gpx']);
+        expect(defaultGroup.realSize).toBe(1);
+    });
+
+    test('the groups above the track are updated too', async () => {
+        const ctx = ctxWithGroups(['Root.gpx', 'Folder/Nested/Deep.gpx']);
+
+        await deleteTrack({ file: { name: 'Folder/Nested/Deep.gpx' }, ctx, ltx: LOGGED_IN });
+
+        const folder = findGroupByName(ctx.tracksGroups, 'Folder');
+        expect(folder.files).toEqual([]);
+        expect(folder.realSize).toBe(0);
+        const defaultGroup = findGroupByName(ctx.tracksGroups, '');
+        expect(defaultGroup.files.map((f) => f.name)).toEqual(['Root.gpx']);
+        expect(defaultGroup.realSize).toBe(1);
+    });
+
+    test('the folder date follows the deleted track', async () => {
+        const ctx = ctxWithGroups(['Folder/Old.gpx', 'Folder/New.gpx'], (name) =>
+            name.endsWith('New.gpx') ? 5000 : 1000
+        );
+
+        await deleteTrack({ file: { name: 'Folder/New.gpx' }, ctx, ltx: LOGGED_IN });
+
+        expect(findGroupByName(ctx.tracksGroups, 'Folder').lastModifiedMs).toBe(1000);
     });
 
     test('a track is deleted even when the groups are not loaded yet', async () => {

--- a/tests/unit/src/tests/tracks/07-refresh-files.test.js
+++ b/tests/unit/src/tests/tracks/07-refresh-files.test.js
@@ -1,0 +1,177 @@
+import { refreshGlobalFiles } from '@map/manager/track/SaveTrackManager';
+import { findGroupByName, TRACK_VISIBLE_FLAG } from '@map/manager/track/TracksManager';
+import { SMART_TYPE } from '@map/menu/share/shareConstants';
+import { apiGet } from '@map/util/HttpApi';
+import { createCtx } from '../../util/fixtures/tracks';
+
+function file(name, updatetimems = 1000, details = undefined) {
+    return { name, type: 'GPX', updatetimems, updatetime: new Date(updatetimems).toISOString(), details };
+}
+
+function smartFolder(name) {
+    return {
+        name,
+        fullName: name,
+        type: SMART_TYPE,
+        subfolders: [],
+        groupFiles: [],
+        files: [],
+        userFilePaths: [],
+    };
+}
+
+function serverFiles(uniqueFiles) {
+    apiGet.mockImplementation(async () => ({ json: async () => ({ uniqueFiles }) }));
+}
+
+describe('refreshGlobalFiles', () => {
+    test('the file list is reloaded and the track groups are rebuilt from it', async () => {
+        const ctx = createCtx();
+        serverFiles([file('Folder/Track.gpx'), file('Loose.gpx')]);
+
+        await refreshGlobalFiles({ ctx });
+
+        expect(ctx.listFiles.uniqueFiles).toHaveLength(2);
+        expect(findGroupByName(ctx.tracksGroups, 'Folder').groupFiles.map((f) => f.name)).toEqual(['Folder/Track.gpx']);
+        expect(findGroupByName(ctx.tracksGroups, '').groupFiles.map((f) => f.name)).toEqual(['Loose.gpx']);
+    });
+
+    test('only gpx files become groups', async () => {
+        const ctx = createCtx();
+        serverFiles([file('Folder/Track.gpx'), { ...file('Folder/Track.gpx.info'), type: 'GPX' }]);
+
+        await refreshGlobalFiles({ ctx });
+
+        expect(findGroupByName(ctx.tracksGroups, 'Folder').realSize).toBe(1);
+    });
+
+    test('smart folders survive a refresh', async () => {
+        const ctx = createCtx();
+        ctx.tracksGroups = [smartFolder('My smart folder')];
+        serverFiles([file('Folder/Track.gpx')]);
+
+        await refreshGlobalFiles({ ctx });
+
+        expect(ctx.tracksGroups.map((g) => g.fullName)).toContain('My smart folder');
+    });
+
+    test('an empty file list leaves only the smart folders', async () => {
+        const ctx = createCtx();
+        ctx.tracksGroups = [smartFolder('My smart folder'), { name: 'Folder', fullName: 'Folder' }];
+        apiGet.mockImplementation(async () => ({ json: async () => ({}) }));
+
+        await refreshGlobalFiles({ ctx });
+
+        expect(ctx.tracksGroups.map((g) => g.fullName)).toEqual(['My smart folder']);
+    });
+
+    test('files whose details are outdated are queued for an update', async () => {
+        const ctx = createCtx();
+        serverFiles([
+            file('Fresh.gpx', 1000, { update: false }),
+            file('Outdated.gpx', 2000, { update: true, updatetime: 'time' }),
+        ]);
+
+        await refreshGlobalFiles({ ctx });
+
+        expect(ctx.setUpdateFiles).toHaveBeenCalledWith([
+            { name: 'Outdated.gpx', type: 'GPX', isError: false, time: 'time' },
+        ]);
+    });
+});
+
+describe('refreshGlobalFiles: the file is already in the list', () => {
+    const NOW = 1750000000000;
+
+    beforeEach(() => {
+        jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    });
+
+    function ctxWithGroups() {
+        const ctx = createCtx({ uniqueFiles: [file('Folder/Nested/Track.gpx')] });
+        ctx.tracksGroups = [
+            {
+                name: 'Folder',
+                fullName: 'Folder',
+                groupFiles: [],
+                files: [file('Folder/Nested/Track.gpx')],
+                subfolders: [
+                    {
+                        name: 'Nested',
+                        fullName: 'Folder/Nested',
+                        groupFiles: [file('Folder/Nested/Track.gpx')],
+                        files: [file('Folder/Nested/Track.gpx')],
+                        subfolders: [],
+                    },
+                ],
+            },
+        ];
+        return ctx;
+    }
+
+    test('the list is not reloaded', async () => {
+        const ctx = ctxWithGroups();
+
+        await refreshGlobalFiles({ ctx, currentFileName: 'Folder/Nested/Track.gpx' });
+
+        expect(apiGet).not.toHaveBeenCalled();
+    });
+
+    test('the save time of the file is updated in every group holding it', async () => {
+        const ctx = ctxWithGroups();
+
+        await refreshGlobalFiles({ ctx, currentFileName: 'Folder/Nested/Track.gpx' });
+
+        const nested = findGroupByName(ctx.tracksGroups, 'Folder/Nested');
+        expect(nested.groupFiles[0].updatetimems).toBe(NOW);
+        expect(nested.files[0].updatetimems).toBe(NOW);
+        expect(findGroupByName(ctx.tracksGroups, 'Folder').files[0].updatetimems).toBe(NOW);
+    });
+
+    test('the folder date follows the file that was saved', async () => {
+        const ctx = ctxWithGroups();
+
+        await refreshGlobalFiles({ ctx, currentFileName: 'Folder/Nested/Track.gpx' });
+
+        const nested = findGroupByName(ctx.tracksGroups, 'Folder/Nested');
+        expect(nested.lastModifiedMs).toBe(NOW);
+        expect(nested.lastModifiedDate).toBe(NOW);
+        expect(findGroupByName(ctx.tracksGroups, 'Folder').lastModifiedMs).toBe(NOW);
+    });
+
+    test('other files keep their save time', async () => {
+        const ctx = ctxWithGroups();
+        ctx.listFiles.uniqueFiles.push(file('Folder/Nested/Other.gpx'));
+        findGroupByName(ctx.tracksGroups, 'Folder/Nested').groupFiles.push(file('Folder/Nested/Other.gpx'));
+
+        await refreshGlobalFiles({ ctx, currentFileName: 'Folder/Nested/Track.gpx' });
+
+        const nested = findGroupByName(ctx.tracksGroups, 'Folder/Nested');
+        expect(nested.groupFiles.find((f) => f.name === 'Folder/Nested/Other.gpx').updatetimems).toBe(1000);
+    });
+});
+
+describe('refreshGlobalFiles: rename', () => {
+    beforeEach(() => {
+        serverFiles([file('Folder/New.gpx')]);
+    });
+
+    test('the renamed track is no longer shown on the map under the old name', async () => {
+        const ctx = createCtx();
+        ctx.gpxFiles = { 'Folder/Old.gpx': { name: 'Folder/Old.gpx', url: null, type: 'GPX' } };
+
+        await refreshGlobalFiles({ ctx, oldName: 'Folder/Old.gpx', currentFileName: 'Folder/New.gpx' });
+
+        expect(ctx.gpxFiles['Folder/Old.gpx'].url).toBeNull();
+        expect(ctx.gpxFiles['Folder/New.gpx']).toBeDefined();
+    });
+
+    test('the visible tracks keep the track under its new name', async () => {
+        localStorage.setItem(TRACK_VISIBLE_FLAG, JSON.stringify({ new: ['Folder/Old.gpx'], old: [], open: [] }));
+        const ctx = createCtx();
+
+        await refreshGlobalFiles({ ctx, oldName: 'Folder/Old.gpx', currentFileName: 'Folder/New.gpx' });
+
+        expect(JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG)).new).toEqual(['Folder/New.gpx']);
+    });
+});

--- a/tests/unit/src/tests/tracks/08-refresh-info-files.test.js
+++ b/tests/unit/src/tests/tracks/08-refresh-info-files.test.js
@@ -1,0 +1,143 @@
+import { applyRefreshedInfoFilesToGpx, getFilesForUpdateDetails } from '@map/util/hooks/useInitialFilesLoad';
+import { EMPTY_FILE_NAME } from '@map/manager/track/TracksManager';
+
+function gpxFile(name, details) {
+    return { name, type: 'GPX', details };
+}
+
+/** Row of the refresh-list-files response: the .info file with its parsed content. */
+function infoRow(gpxName, data) {
+    return { name: gpxName + '.info', details: data === undefined ? {} : { data } };
+}
+
+describe('getFilesForUpdateDetails', () => {
+    test('only files whose details are outdated are taken', () => {
+        const setUpdateFiles = jest.fn();
+        const files = [
+            gpxFile('Folder/Track.gpx', { update: true, updatetime: 100 }),
+            gpxFile('Folder/Fresh.gpx', { update: false }),
+            gpxFile('Folder/NoDetails.gpx', undefined),
+        ];
+
+        expect(getFilesForUpdateDetails(files, setUpdateFiles)).toBe(true);
+        expect(setUpdateFiles).toHaveBeenCalledWith([
+            { name: 'Folder/Track.gpx', type: 'GPX', isError: false, time: 100 },
+        ]);
+    });
+
+    test('info files are updated together with the tracks', () => {
+        const setUpdateFiles = jest.fn();
+        const files = [gpxFile('Folder/Track.gpx.info', { update: true, updatetime: 100 })];
+
+        getFilesForUpdateDetails(files, setUpdateFiles);
+
+        expect(setUpdateFiles.mock.calls[0][0].map((f) => f.name)).toEqual(['Folder/Track.gpx.info']);
+    });
+
+    test('folder placeholders are never updated', () => {
+        const setUpdateFiles = jest.fn();
+        const files = [gpxFile('Folder/' + EMPTY_FILE_NAME, { update: true })];
+
+        expect(getFilesForUpdateDetails(files, setUpdateFiles)).toBe(false);
+        expect(setUpdateFiles).not.toHaveBeenCalled();
+    });
+
+    test('files of other types are never updated', () => {
+        const setUpdateFiles = jest.fn();
+        const files = [{ name: 'favorites.gpx', type: 'FAVOURITES', details: { update: true } }];
+
+        expect(getFilesForUpdateDetails(files, setUpdateFiles)).toBe(false);
+        expect(setUpdateFiles).not.toHaveBeenCalled();
+    });
+
+    test('a file whose details failed to be read is marked as an error', () => {
+        const setUpdateFiles = jest.fn();
+        const files = [gpxFile('Track.gpx', { update: true, error: 'broken', updatetime: 100 })];
+
+        getFilesForUpdateDetails(files, setUpdateFiles);
+
+        expect(setUpdateFiles.mock.calls[0][0][0].isError).toBe(true);
+    });
+});
+
+describe('applyRefreshedInfoFilesToGpx', () => {
+    function apply(rows, { gpxFiles = {}, track = null } = {}) {
+        const setGpxFiles = jest.fn();
+        const setSelectedGpxFile = jest.fn();
+
+        applyRefreshedInfoFilesToGpx(rows, setGpxFiles, setSelectedGpxFile);
+
+        return {
+            setGpxFiles,
+            setSelectedGpxFile,
+            files: setGpxFiles.mock.calls[0]?.[0](gpxFiles),
+            selected: setSelectedGpxFile.mock.calls[0]?.[0](track),
+        };
+    }
+
+    test('the refreshed info is merged into the loaded track', () => {
+        const gpxFiles = { 'Folder/Track.gpx': { name: 'Folder/Track.gpx', info: { color: '#ff0000', width: '3' } } };
+
+        const { files } = apply([infoRow('Folder/Track.gpx', { color: '#00ff00' })], { gpxFiles });
+
+        expect(files['Folder/Track.gpx'].info).toEqual({ color: '#00ff00', width: '3' });
+        expect(files['Folder/Track.gpx'].cloudRedrawWpts).toBe(true);
+    });
+
+    test('tracks without a refreshed info file are kept as they are', () => {
+        const other = { name: 'Other.gpx', info: { color: '#ff0000' } };
+        const gpxFiles = { 'Folder/Track.gpx': { name: 'Folder/Track.gpx' }, 'Other.gpx': other };
+
+        const { files } = apply([infoRow('Folder/Track.gpx', { color: '#00ff00' })], { gpxFiles });
+
+        expect(files['Other.gpx']).toBe(other);
+    });
+
+    test('the loaded tracks are not touched when nothing matches', () => {
+        const gpxFiles = { 'Other.gpx': { name: 'Other.gpx' } };
+
+        const { files } = apply([infoRow('Folder/Track.gpx', { color: '#00ff00' })], { gpxFiles });
+
+        expect(files).toBe(gpxFiles);
+    });
+
+    test('an info file without content leaves the loaded track alone', () => {
+        const gpxFiles = { 'Folder/Track.gpx': { name: 'Folder/Track.gpx', info: { color: '#ff0000' } } };
+
+        const { files } = apply([infoRow('Folder/Track.gpx')], { gpxFiles });
+
+        expect(files).toBe(gpxFiles);
+    });
+
+    test('a response without info files is ignored', () => {
+        const { setGpxFiles, setSelectedGpxFile } = apply([{ name: 'Folder/Track.gpx', details: {} }]);
+
+        expect(setGpxFiles).not.toHaveBeenCalled();
+        expect(setSelectedGpxFile).not.toHaveBeenCalled();
+    });
+
+    test('the open track gets the refreshed info', () => {
+        const track = { name: 'Folder/Track.gpx', info: { color: '#ff0000', width: '3' } };
+
+        const { selected } = apply([infoRow('Folder/Track.gpx', { color: '#00ff00' })], { track });
+
+        expect(selected.info).toEqual({ color: '#00ff00', width: '3' });
+        expect(selected.cloudRedrawWpts).toBe(true);
+    });
+
+    test('unsaved appearance changes of the open track are kept', () => {
+        const track = { name: 'Folder/Track.gpx', info: { color: '#ff0000' }, infoChanged: true };
+
+        const { selected } = apply([infoRow('Folder/Track.gpx', { color: '#00ff00' })], { track });
+
+        expect(selected).toBe(track);
+    });
+
+    test('an info file without content leaves the open track alone', () => {
+        const track = { name: 'Folder/Track.gpx', info: { color: '#ff0000' } };
+
+        const { selected } = apply([infoRow('Folder/Track.gpx')], { track });
+
+        expect(selected).toBe(track);
+    });
+});

--- a/tests/unit/src/tests/tracks/09-visible-tracks.test.js
+++ b/tests/unit/src/tests/tracks/09-visible-tracks.test.js
@@ -1,0 +1,115 @@
+import {
+    getCountVisibleTracks,
+    hideAllVisTracks,
+    isVisibleTrack,
+    showAllVisTracks,
+    updateVisibleCache,
+    VISIBLE_SHARE_MARKER,
+} from '@map/menu/visibletracks/VisibleTracks';
+import { TRACK_VISIBLE_FLAG } from '@map/manager/track/TracksManager';
+import { SHARE_TYPE } from '@map/menu/share/shareConstants';
+
+function savedVisible(value) {
+    localStorage.setItem(TRACK_VISIBLE_FLAG, JSON.stringify(value));
+}
+
+function readVisible() {
+    return JSON.parse(localStorage.getItem(TRACK_VISIBLE_FLAG));
+}
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+describe('updateVisibleCache', () => {
+    test('an opened track is added to the cache', () => {
+        savedVisible({ old: [], new: [], open: [] });
+
+        updateVisibleCache({ visible: true, file: { name: 'Folder/Track.gpx' } });
+
+        expect(readVisible().open).toEqual(['Folder/Track.gpx']);
+    });
+
+    test('a closed track is dropped from the cache', () => {
+        savedVisible({ old: [], new: [], open: ['Folder/Track.gpx', 'Other.gpx'] });
+
+        updateVisibleCache({ visible: false, file: { name: 'Folder/Track.gpx' } });
+
+        expect(readVisible().open).toEqual(['Other.gpx']);
+    });
+
+    test('a shared track is marked as shared in the cache', () => {
+        savedVisible({ old: [], new: [], open: [] });
+
+        updateVisibleCache({ visible: true, file: { name: 'Track.gpx' }, smartf: { type: SHARE_TYPE } });
+
+        expect(readVisible().open).toEqual([VISIBLE_SHARE_MARKER + 'Track.gpx']);
+    });
+
+    test('the cache of an older version without open tracks is upgraded', () => {
+        savedVisible({ old: ['Old.gpx'], new: [] });
+
+        updateVisibleCache({ visible: true, file: { name: 'Track.gpx' } });
+
+        expect(readVisible()).toEqual({ old: ['Old.gpx'], new: [], open: ['Track.gpx'] });
+    });
+
+    test('an empty cache is created on the first opened track', () => {
+        updateVisibleCache({ visible: true, file: { name: 'Track.gpx' } });
+
+        expect(readVisible()).toEqual({ old: [], new: [], open: ['Track.gpx'] });
+    });
+});
+
+describe('isVisibleTrack', () => {
+    test('a track shown on the map is visible', () => {
+        savedVisible({ open: ['Folder/Track.gpx'] });
+
+        expect(isVisibleTrack({ name: 'Folder/Track.gpx' })).toBe(true);
+        expect(isVisibleTrack({ name: 'Other.gpx' })).toBe(false);
+    });
+
+    test('a shared track shown on the map is visible', () => {
+        savedVisible({ open: [] });
+        updateVisibleCache({ visible: true, file: { name: 'Track.gpx' }, smartf: { type: SHARE_TYPE } });
+
+        expect(isVisibleTrack({ name: 'Track.gpx', sharedWithMe: true })).toBe(true);
+    });
+
+    test('an empty cache means nothing is visible', () => {
+        expect(isVisibleTrack({ name: 'Track.gpx' })).toBe(false);
+    });
+});
+
+describe('hideAllVisTracks / showAllVisTracks', () => {
+    test('hiding all clears the opened tracks and keeps the lists', () => {
+        savedVisible({ old: ['Old.gpx'], new: ['New.gpx'], open: ['New.gpx'] });
+
+        hideAllVisTracks();
+
+        expect(readVisible()).toEqual({ old: ['Old.gpx'], new: ['New.gpx'], open: [] });
+    });
+
+    test('showing all opens every known track', () => {
+        savedVisible({ old: ['Old.gpx'], new: ['New.gpx'], open: [] });
+
+        showAllVisTracks();
+
+        expect(readVisible().open).toEqual(['Old.gpx', 'New.gpx']);
+    });
+
+    test('an empty cache is left empty', () => {
+        hideAllVisTracks();
+        showAllVisTracks();
+
+        expect(localStorage.getItem(TRACK_VISIBLE_FLAG)).toBeNull();
+    });
+});
+
+describe('getCountVisibleTracks', () => {
+    test('only the recently opened tracks are counted', () => {
+        expect(getCountVisibleTracks({ new: ['A.gpx', 'B.gpx'], old: ['C.gpx'] })).toBe(2);
+        expect(getCountVisibleTracks({ old: ['C.gpx'] })).toBe(0);
+        expect(getCountVisibleTracks(null)).toBe(0);
+    });
+});

--- a/tests/unit/src/util/fixtures/tracks.js
+++ b/tests/unit/src/util/fixtures/tracks.js
@@ -31,7 +31,12 @@ export function createCtx({ track, cloud = true, uniqueFiles = [] } = {}) {
         listFiles: { uniqueFiles },
         gpxFiles: {},
         tracksGroups: [],
-        mutateGpxFiles: jest.fn(),
+        // useMutator: the callback gets a shallow copy of the previous state and mutates it
+        mutateGpxFiles: jest.fn((update) => {
+            const next = { ...ctx.gpxFiles };
+            update(next);
+            ctx.gpxFiles = next;
+        }),
         setTracksGroups: setter('tracksGroups'),
         setCreateTrack: jest.fn(),
         setListFiles: setter('listFiles'),

--- a/tests/unit/src/util/fixtures/tracks.js
+++ b/tests/unit/src/util/fixtures/tracks.js
@@ -30,8 +30,12 @@ export function createCtx({ track, cloud = true, uniqueFiles = [] } = {}) {
         gpxFiles: {},
         tracksGroups: [],
         mutateGpxFiles: jest.fn(),
-        setTracksGroups: jest.fn(),
+        setTracksGroups: jest.fn((groups) => (ctx.tracksGroups = groups)),
         setCreateTrack: jest.fn(),
+        setListFiles: jest.fn((listFiles) => (ctx.listFiles = listFiles)),
+        setGpxFiles: jest.fn((gpxFiles) => (ctx.gpxFiles = gpxFiles)),
+        setUpdateFiles: jest.fn(),
+        setSelectedSort: jest.fn(),
         setSelectedGpxFile: (update) => {
             ctx.selectedGpxFile = typeof update === 'function' ? update(ctx.selectedGpxFile) : update;
         },

--- a/tests/unit/src/util/fixtures/tracks.js
+++ b/tests/unit/src/util/fixtures/tracks.js
@@ -21,6 +21,8 @@ export function createTrack({ name, pointsGroups = createPointsGroups(), info = 
 }
 
 export function createCtx({ track, cloud = true, uniqueFiles = [] } = {}) {
+    // the app calls the setters both with a value and with an updater, as react does
+    const setter = (key) => jest.fn((update) => (ctx[key] = typeof update === 'function' ? update(ctx[key]) : update));
     const ctx = {
         currentObjectType: cloud ? OBJECT_TYPE_CLOUD_TRACK : OBJECT_TYPE_LOCAL_TRACK,
         selectedGpxFile: track,
@@ -30,15 +32,19 @@ export function createCtx({ track, cloud = true, uniqueFiles = [] } = {}) {
         gpxFiles: {},
         tracksGroups: [],
         mutateGpxFiles: jest.fn(),
-        setTracksGroups: jest.fn((groups) => (ctx.tracksGroups = groups)),
+        setTracksGroups: setter('tracksGroups'),
         setCreateTrack: jest.fn(),
-        setListFiles: jest.fn((listFiles) => (ctx.listFiles = listFiles)),
-        setGpxFiles: jest.fn((gpxFiles) => (ctx.gpxFiles = gpxFiles)),
+        setListFiles: setter('listFiles'),
+        setGpxFiles: setter('gpxFiles'),
         setUpdateFiles: jest.fn(),
         setSelectedSort: jest.fn(),
-        setSelectedGpxFile: (update) => {
-            ctx.selectedGpxFile = typeof update === 'function' ? update(ctx.selectedGpxFile) : update;
-        },
+        setSmartFoldersCache: jest.fn(),
+        setShareWithMeFiles: jest.fn(),
+        setVisibleTracks: jest.fn(),
+        setCurrentObjectType: jest.fn(),
+        openGroups: [],
+        setOpenGroups: jest.fn(),
+        setSelectedGpxFile: setter('selectedGpxFile'),
         setTrackErrorMsg: jest.fn(),
     };
 

--- a/tests/unit/src/util/requests.js
+++ b/tests/unit/src/util/requests.js
@@ -5,7 +5,10 @@ export function findRequest(apiMock, endpoint) {
         const sent = apiMock.mock.calls.map(([url]) => url).join(', ') || 'nothing';
         throw new Error(`No request to ${endpoint}, sent: ${sent}`);
     }
-    const [url, body, options] = call;
+    // apiPost(url, body, options), apiGet(url, options)
+    const [url, ...rest] = call;
+    const body = rest.length > 1 ? rest[0] : undefined;
+    const options = rest.length > 1 ? rest[1] : rest[0];
 
     return { url, body, options };
 }


### PR DESCRIPTION
## Unit tests for cloud tracks + fixes for the bugs they found

Adds unit-test coverage for the cloud-track managers (names and paths, folder tree, rename, delete, list refresh, `.info` refresh, visible-tracks cache) and fixes every bug found while writing them. Each fix has a test that fails without it.

### Fixed

- **Renaming a nested folder corrupted the path.** `renameFolder` / `renameSmartFolder` used `fullName.replace(folder.name, newName)`, so for `Trips/Trips` or any path where the folder name occurs earlier, the wrong segment was replaced. Both now use the new `renameLastFolderSegment`.
- **`createTrackGroups` returned `undefined` for an empty file list** — `doSort` returns nothing when there is nothing to sort, while every caller expects a list.
- **Deleting a track updated at most one group.** `deleteTracksFromGroups` looked up the group by path and compared the bare file name against `groupFiles` / `files`, which hold the full cloud name, so nothing was spliced and `realSize` was never decremented. Even with the name fixed, the groups above the track (the parent folder, the default group) kept the deleted entry in `files` with a stale `realSize` and last-modified date, and for a root track the default group's `groupFiles` was left untouched whenever that group owns subfolders. Replaced with a recursive walk that removes the track from every group holding it and recomputes `realSize` and the last-modified date there.
- **A file of a nested folder was listed twice.** `addFilesAndCalculateLastModified` pushes the subfolders' files into `group.files` without the duplicate guard used a few lines below, and a folder is visited twice once the default group adopts it as a subfolder. Not visible in the UI (the lists render `groupFiles`), but the tree was wrong.
- **The folder date did not follow a re-saved track.** When a track is saved over an existing one, `updateUpdatetimemsInGroups` bumped the file time but never recalculated `lastModifiedMs` / `lastModifiedDate`, which the folder row displays and date sorting uses.
- **An empty `.info` triggered a pointless merge and redraw** in `applyRefreshedInfoFilesToGpx`; it now behaves like the open-track branch and skips a row without data.
- **A hidden waypoint group came back when the map layer was rebuilt.** `updateGroupsVisibility` updated only `ctx.selectedGpxFile`, while `addTrackToMap` draws waypoints from `ctx.gpxFiles[name].info`; the loaded track is now kept in sync, as the local-track branch already does for `ctx.localTracks`.
- **Visible-tracks cache:** `isVisibleTrack` looked up shared tracks without the `share_visible_marker_` prefix that `updateVisibleCache` writes, so a visible shared track was treated as hidden and dropped from the map when the info block was closed; `updateVisibleCache` threw on an empty cache; `hideAllVisTracks` / `showAllVisTracks` wrote the string `"null"` into localStorage.

### Tests

New and extended suites in `tests/unit/src/tests/tracks/`: `01` (waypoint-group visibility), `04` (folder tree), `05` (rename), `06` (delete), `07` (list refresh), `08` (`.info` refresh), `09` (visible-tracks cache) — 243 tests total, ~9 s.

`jest.config.js`: `useInitialFilesLoad` un-stubbed, `shareConstants` and `VisibleTracks` wired to the real files.