### PR TITLE
Wait for the site to go idle before leaving a freshly imported cloud track

### DIFF
--- a/tests/selenium/src/actions/tracks/actionImportCloudTrack.mjs
+++ b/tests/selenium/src/actions/tracks/actionImportCloudTrack.mjs
@@ -5,6 +5,35 @@ import actionUploadCloudTracks from './actionUploadCloudTracks.mjs';
 import actionDeleteTracksByPattern from './actionDeleteTracksByPattern.mjs';
 import { driver } from '../../options.mjs';
 
+const MAX_BACK_ATTEMPTS = 3;
+
+/**
+ * Return from the track menu to the list of the folder the track was uploaded into.
+ *
+ * A single-file upload is opened by the site (useGpxImport: selected = files.length === 1),
+ * so the track menu covers the folder list. saveTrackToCloud() keeps working after that menu
+ * shows up - downloadAfterUpload/refreshGlobalFiles/syncCloudTrackInfo are not awaited - and
+ * clicking back while they are still running lets them re-open the track over the list.
+ * Waiting for the site to go idle first, and checking where we ended up after the click,
+ * removes both the early click and the assumption that the upload opens the track at all.
+ */
+async function actionBackToFolder(newName) {
+    const listItem = By.id(`se-cloud-track-${newName}`);
+    for (let attempt = 1; attempt <= MAX_BACK_ATTEMPTS; attempt++) {
+        await actionIdleWait();
+        if (await waitBy(By.id('se-track-context-menu'), { optional: true })) {
+            await clickBy(By.id('se-button-back'));
+            await actionIdleWait();
+            if (await waitBy(By.id('se-track-context-menu'), { optional: true })) {
+                console.log(`Track menu re-opened after back, attempt #${attempt}`);
+                continue;
+            }
+        }
+        return await waitBy(listItem);
+    }
+    throw new Error(`Unable to leave the track menu after importing ${newName}`);
+}
+
 export default async function test(tracks, trackName = null, newName = trackName) {
     await actionIdleWait();
     if (!trackName) {
@@ -18,8 +47,7 @@ export default async function test(tracks, trackName = null, newName = trackName
 
     while (retries < maxRetries) {
         await actionUploadCloudTracks({ files: path });
-        await clickBy(By.id('se-button-back'));
-        await waitBy(By.id(`se-cloud-track-${newName}`));
+        await actionBackToFolder(newName);
 
         const elems = await driver.findElements(By.css(`[id^="se-cloud-track-${newName}"]`));
         if (elems.length <= 1) {


### PR DESCRIPTION
Fixes osmandapp/OsmAnd-Issues#3322

`WebSite_UITests` #9681 went red on one test:

```
[1/5] FAILED tracks/03-mini-create-g-upload-t-delete-g.mjs (315.38s)
      Waiting waitBy*[id="se-back-folder-button-tracks"] — Wait timed out after 300142ms
```

The site itself did not change — the `web` revision is the same `829f8d235` in the green #9680 and the red #9681. The failure screenshot shows the app sitting on the track menu of the just-uploaded `test-routed-osrm` instead of the folder list, where `se-back-folder-button-tracks` does not exist.

## Why

A single-file cloud upload is opened by the site (`useGpxImport`: `selected = files.length === 1`), so the track menu covers the folder list, and `actionImportCloudTrack` clicked `se-button-back` as soon as that button appeared. `saveTrackToCloud()` is not finished at that moment: `downloadAfterUpload()`, `refreshGlobalFiles()` and `syncCloudTrackInfo()` are fired without `await` (`map/src/manager/track/SaveTrackManager.js:139-150`), and their late `setSelectedGpxFile` re-opens the track over the list.

Measured on osmand.net at the exact point of that click, three runs:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| track menu appears after | 736 ms | 629 ms | 685 ms |
| `actionIdleWait()` blocks there | 1474 ms | 1442 ms | 1433 ms |

`IDLE_DELAY` is 1000 ms, so roughly 450 ms of network activity is still ahead of the click on a fast local connection, and more on the builder.

## Change

`actionImportCloudTrack` now waits for the site to go idle before leaving the track menu, and checks afterwards whether it actually left, retrying the back click up to three times. The menu is looked for rather than assumed, so an upload that does not open the track lands on the folder list instead of waiting 300 s for `se-button-back` — the other failure of this test in the last 500 builds, #9459 (2026-08-27).

## Testing

The race was not reproducible locally (it needs the builder's slower connection), so this is verified as "no regression plus the measured window is now closed", not as a reproduced-and-fixed failure.

All tests that import a cloud track, against osmand.net, headless:

```
[1/6] PASS tracks/03-mini-create-g-upload-t-delete-g.mjs (24.73s)
[2/6] PASS tracks/13-uploud-track-to-cloud.mjs (36.68s)
[3/6] PASS tracks/27-upload-kmz-to-cloud.mjs (34.44s)
[4/6] PASS tracks/62-rename-track.mjs (38.45s)
[5/6] PASS tracks/63-duplicate-track.mjs (40.56s)
[6/6] PASS tracks/96-changes-cloud.mjs (46.96s)
```

The remaining importers, same site and settings:

```
[1/3] PASS tracks/14-sort-tracks.mjs (38.06s)
[2/3] PASS menu/98-trash.mjs (94.02s)
[3/3] PASS menu/99-share.mjs (222.52s)
```

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. "What fell, can you fix it?" with a link to the `WebSite_UITests` Jenkins job.
2. A pointer to the console output of build #9681.
3. Asked whether the alternative-routes commits broke the web test, and whether it is a bug or a test problem.
4. "Let's harden option 2" — i.e. make the test robust rather than only rerunning the build.
5. "How often did it fail?"
6. Create an internal issue (release backlog → Code Review → 5.5-map, current iteration) and this PR.

Decided by the agent, not requested explicitly:
- The shape of the fix: idle-wait plus a bounded verify-and-retry loop in `actionBackToFolder`, rather than a fixed sleep or a longer timeout.
- Looking for the track menu instead of assuming the upload opens it, which also covers the #9459 failure mode; that was not asked for.
- Measuring the idle window over three runs to justify the change, and running every test that imports a cloud track rather than only the failing one.
- The issue text, labels (`website`, `test-auto`) and the milestone choice within what was requested.
