### PR TITLE
Add unit tests

### DIFF
--- a/map/src/context/LocalTrackStorage.js
+++ b/map/src/context/LocalTrackStorage.js
@@ -181,10 +181,7 @@ export function deleteLocalTrack(ctx, index = -1) {
     const currentTrackIndex =
         index !== -1 ? index : ctx.localTracks.findIndex((t) => t?.name === ctx.selectedGpxFile?.name);
     if (currentTrackIndex !== -1) {
-        deleteTrackFromDB(currentTrackIndex).then(() => {
-            ctx.localTracks.splice(currentTrackIndex, 1);
-            ctx.setLocalTracks([...ctx.localTracks]);
-        });
+        deleteLocalTracksByIndexes(ctx, [currentTrackIndex]);
     }
 }
 
@@ -221,12 +218,8 @@ export function deleteLocalTracksByIndexes(ctx, indexes = []) {
                     }
                 }
 
-                // collect all ids to remove: deleted + moved-from
-                const idsToRemove = new Set([...toDelete, ...moves.map(({ oldId }) => oldId)]);
-
-                // delete old ids
-                for (const oldId of idsToRemove) {
-                    await deleteTrackFromDB(oldId);
+                for (let id = next.length; id < prev.length; id++) {
+                    await deleteTrackFromDB(id);
                 }
             } catch (e) {
                 DEBUG && console.error('Failed to delete selected local tracks', e);

--- a/map/src/context/LocalTrackStorage.js
+++ b/map/src/context/LocalTrackStorage.js
@@ -218,6 +218,7 @@ export function deleteLocalTracksByIndexes(ctx, indexes = []) {
                     }
                 }
 
+                // the ids past the new length are free after the tracks left were saved over the first ones
                 for (let id = next.length; id < prev.length; id++) {
                     await deleteTrackFromDB(id);
                 }

--- a/map/src/manager/FavoritesManager.js
+++ b/map/src/manager/FavoritesManager.js
@@ -409,14 +409,14 @@ export function createFavGroupFreeName(name, groups) {
 }
 
 export function isFavGroupExists(name, groups) {
-    return groups && groups.some((g) => g.name === name);
+    return groups?.some((g) => g.name === name);
 }
 
 function isHidden(pointsGroups, name) {
     let group = pointsGroups[name];
-    if (group && group.points) {
+    if (group?.points) {
         for (let point of group.points) {
-            if (point.ext.extensions.hidden === 'true') {
+            if (point.ext?.extensions?.hidden === 'true') {
                 return true;
             }
         }

--- a/map/src/manager/WeatherManager.js
+++ b/map/src/manager/WeatherManager.js
@@ -127,9 +127,10 @@ export function updateWeatherTime(wtx, hours) {
     wtx.setWeatherDate(dt);
 }
 
+// the forecast rows are keyed by utc, as the tiles are
 export function dayFormatter(date) {
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
     return month + day;
 }
 

--- a/map/src/map/layers/PoiLayer.js
+++ b/map/src/map/layers/PoiLayer.js
@@ -64,7 +64,6 @@ export async function createPoiLayer({ ctx, poiList = [], globalPoiIconCache, ty
         places: poiList,
         zoom,
         latitude,
-        iconSize: DEFAULT_ICON_SIZE,
         isPoi: true,
     });
 

--- a/map/src/map/layers/SearchLayer.js
+++ b/map/src/map/layers/SearchLayer.js
@@ -366,7 +366,6 @@ export default function SearchLayer() {
             places: mapMarkerFeatures,
             zoom,
             latitude,
-            iconSize: DEFAULT_ICON_SIZE,
             isPoi: true,
         });
 

--- a/map/src/map/layers/TransportStopsLayer.js
+++ b/map/src/map/layers/TransportStopsLayer.js
@@ -6,7 +6,7 @@ import { apiGet } from '../../util/HttpApi';
 import { findFeatureGroupById, bindTooltipToMarker, createTooltip, TOOLTIP_MAX_LENGTH } from '../util/MapManager';
 import { getVisibleBboxInfo } from './MapStateLayer';
 import L from 'leaflet';
-import { changeIconColor, createPoiIcon, DEFAULT_ICON_SIZE } from '../markers/MarkerOptions';
+import { changeIconColor, createPoiIcon } from '../markers/MarkerOptions';
 import { clusterMarkers, removeTooltip } from '../util/Clusterizer';
 import Utils from '../../util/Utils';
 import { SimpleDotMarker } from '../markers/SimpleDotMarker';
@@ -88,7 +88,6 @@ async function createTransportStopsLayer({ stopsList = [], map, zoom, onClick, c
         places: stopsList,
         zoom,
         latitude,
-        iconSize: DEFAULT_ICON_SIZE,
         isPoi: true,
     });
 

--- a/map/src/map/layers/TravelLayer.js
+++ b/map/src/map/layers/TravelLayer.js
@@ -239,8 +239,8 @@ export default function TravelLayer() {
                     places,
                     zoom,
                     latitude: center.lat,
-                    iconSize: 8,
-                    secondaryIconSize: 4,
+                    mainRadiusPx: 8,
+                    secondaryRadiusPx: 4,
                     isPoi: true,
                 });
 

--- a/map/src/map/util/Clusterizer.js
+++ b/map/src/map/util/Clusterizer.js
@@ -1,6 +1,5 @@
 import L from 'leaflet';
 import Utils from '../../util/Utils';
-import { getPointLatLon } from './TrackLayerProvider';
 import { createTooltip, TOOLTIP_MAX_LENGTH } from './MapManager';
 import { getObjIdSearch } from '../../manager/SearchManager';
 import { searchTypeMap } from '../../manager/searchConstants';
@@ -21,6 +20,12 @@ import { getImgByProps, updateMarkerZIndex } from '../layers/ExploreLayer';
 import { SimpleDotMarker } from '../markers/SimpleDotMarker';
 import { MARKER_Z_INDEX_MAIN } from './ZIndexes';
 
+export function getPointLatLon(point) {
+    const lat = point.lat ?? point.ext?.lat;
+    const lon = point.lon ?? point.ext?.lon;
+    return lat != null && lon != null ? { lat: lat, lon: lon } : null;
+}
+
 export const EXPLORE_BIG_ICON_SIZE = 36;
 export const EXPLORE_BIG_REAL_ICON_SIZE = 42;
 export const SIMPLE_ICON_SIZE = 10;
@@ -37,6 +42,8 @@ export function clusterMarkers({
     isPoi = false,
     isFavorites = false,
     isExplore = false,
+    mainRadiusPx = POI_MAIN_RADIUS_PX,
+    secondaryRadiusPx = POI_SECONDARY_RADIUS_PX,
 }) {
     const maxMainPlaces = getMaxMainPlaces(zoom, isPoi, isExplore);
     const maxSecondaryPlaces = getMaxSecondaryPlaces(zoom, isExplore);
@@ -68,7 +75,7 @@ export function clusterMarkers({
     }
 
     if (isPoi) {
-        return createPoiMarkersArr({ places, latitude, zoom });
+        return createPoiMarkersArr({ places, latitude, zoom, mainRadiusPx, secondaryRadiusPx });
     }
 
     // Sort clusters by size
@@ -107,12 +114,12 @@ export function clusterMarkers({
 }
 
 function createExploreMarkersArr({ places, mainMinDistance, secondaryMinDistance, maxMainPlaces, maxSecondaryPlaces }) {
-    places.sort((a, b) => (a.properties.rowNum ?? 0) - (b.properties.rowNum ?? 0));
+    const sorted = [...places].sort((a, b) => (a.properties.rowNum ?? 0) - (b.properties.rowNum ?? 0));
 
     const mainMarkers = [];
-    for (const place of places) {
+    for (const place of sorted) {
         if (
-            mainMarkers.length <= maxMainPlaces &&
+            mainMarkers.length < maxMainPlaces &&
             place.properties.rowNum < 100 &&
             canPlaceMarker({
                 place,
@@ -126,7 +133,7 @@ function createExploreMarkersArr({ places, mainMinDistance, secondaryMinDistance
     }
 
     const secondaryMarkers = [];
-    for (const place of places) {
+    for (const place of sorted) {
         if (secondaryMarkers.length >= maxSecondaryPlaces || mainMarkers.includes(place)) continue;
 
         if (
@@ -150,9 +157,9 @@ function createExploreMarkersArr({ places, mainMinDistance, secondaryMinDistance
 // POI clustering by screen-pixel radius: big markers take the most popular (elo) place
 // first, greedily kept POI_MAIN_RADIUS_PX apart; the rest become small dots kept POI_SECONDARY_RADIUS_PX
 // apart. Both passes prevent overlap.
-function createPoiMarkersArr({ places, latitude, zoom }) {
+function createPoiMarkersArr({ places, latitude, zoom, mainRadiusPx, secondaryRadiusPx }) {
     const mpp = metersPerPixel(latitude, zoom);
-    const mainMinDistance = POI_MAIN_RADIUS_PX * mpp;
+    const mainMinDistance = mainRadiusPx * mpp;
     const valid = (places ?? []).filter(Boolean);
 
     const mainMarkers = [];
@@ -163,7 +170,7 @@ function createPoiMarkersArr({ places, latitude, zoom }) {
     }
     const mainSet = new Set(mainMarkers);
 
-    const secondaryMinDistance = POI_SECONDARY_RADIUS_PX * mpp;
+    const secondaryMinDistance = secondaryRadiusPx * mpp;
     const secondaryMarkers = [];
     const placed = [...mainMarkers];
     for (const place of valid) {

--- a/map/src/map/util/Clusterizer.js
+++ b/map/src/map/util/Clusterizer.js
@@ -1,7 +1,7 @@
 import L from 'leaflet';
 import Utils from '../../util/Utils';
 import { createTooltip, TOOLTIP_MAX_LENGTH } from './MapManager';
-import { getObjIdSearch } from '../../manager/SearchManager';
+import { getObjIdSearch, getIconByType } from '../../manager/SearchManager';
 import { searchTypeMap } from '../../manager/searchConstants';
 import {
     CATEGORY_TYPE,
@@ -13,14 +13,13 @@ import {
     TYPE_OSM_VALUE,
 } from '../../infoblock/components/wpt/WptTagsProvider';
 import PoiManager from '../../manager/PoiManager';
-import { getIconByType } from '../../manager/SearchManager';
 import { processMarkers } from '../layers/FavoriteLayer';
 import { DEFAULT_ICON_SIZE } from '../markers/MarkerOptions';
 import { getImgByProps, updateMarkerZIndex } from '../layers/ExploreLayer';
 import { SimpleDotMarker } from '../markers/SimpleDotMarker';
 import { MARKER_Z_INDEX_MAIN } from './ZIndexes';
 
-export function getPointLatLon(point) {
+function getPointLatLon(point) {
     const lat = point.lat ?? point.ext?.lat;
     const lon = point.lon ?? point.ext?.lon;
     return lat != null && lon != null ? { lat: lat, lon: lon } : null;
@@ -45,24 +44,18 @@ export function clusterMarkers({
     mainRadiusPx = POI_MAIN_RADIUS_PX,
     secondaryRadiusPx = POI_SECONDARY_RADIUS_PX,
 }) {
-    const maxMainPlaces = getMaxMainPlaces(zoom, isPoi, isExplore);
+    if (isPoi) {
+        return createPoiMarkersArr({ places, latitude, zoom, mainRadiusPx, secondaryRadiusPx });
+    }
+
+    const maxMainPlaces = getMaxMainPlaces(isExplore);
     const maxSecondaryPlaces = getMaxSecondaryPlaces(zoom, isExplore);
-    const useUniformMarkerPlacement = getUseUniformMarkerPlacement(zoom, isPoi, isFavorites);
+    const useUniformMarkerPlacement = getUseUniformMarkerPlacement(zoom, isFavorites);
 
     // Minimum distances between markers in meters
-    const mainMinDistance = calculateDistance({
-        iconSize,
-        latitude,
-        zoom,
-        isPoi,
-    });
+    const mainMinDistance = calculateDistance({ iconSize, latitude, zoom });
 
-    const secondaryMinDistance = calculateDistance({
-        iconSize: secondaryIconSize,
-        latitude,
-        zoom,
-        isPoi,
-    });
+    const secondaryMinDistance = calculateDistance({ iconSize: secondaryIconSize, latitude, zoom });
 
     if (isExplore) {
         return createExploreMarkersArr({
@@ -72,10 +65,6 @@ export function clusterMarkers({
             maxMainPlaces,
             maxSecondaryPlaces,
         });
-    }
-
-    if (isPoi) {
-        return createPoiMarkersArr({ places, latitude, zoom, mainRadiusPx, secondaryRadiusPx });
     }
 
     // Sort clusters by size
@@ -96,7 +85,7 @@ export function clusterMarkers({
         };
     }
 
-    const mainMarkers = createMainMarkersArr(clusters, useUniformMarkerPlacement, mainMinDistance, isFavorites, isPoi);
+    const mainMarkers = createMainMarkersArr(clusters, useUniformMarkerPlacement, mainMinDistance, isFavorites);
 
     const secondaryMarkers = createOtherMarkersArr({
         clusters,
@@ -187,13 +176,8 @@ function getPoiElo(place) {
     return Number(place?.properties?.[POI_ELO]) || 0;
 }
 
-function getMaxMainPlaces(zoom, isPoi, isExplore) {
-    if (isPoi) {
-        return 2000;
-    } else if (isExplore) {
-        return 20;
-    }
-    return 50;
+function getMaxMainPlaces(isExplore) {
+    return isExplore ? 20 : 50;
 }
 
 function getMaxSecondaryPlaces(zoom, isExplore) {
@@ -206,18 +190,15 @@ function getMaxSecondaryPlaces(zoom, isExplore) {
     return 900;
 }
 
-function getUseUniformMarkerPlacement(zoom, isPoi, isFavorites) {
-    if (isPoi || isFavorites) {
+function getUseUniformMarkerPlacement(zoom, isFavorites) {
+    if (isFavorites) {
         return true;
     }
     return zoom <= 10 || zoom >= 16;
 }
 
-function calculateDistance({ iconSize, latitude, zoom, isPoi = false }) {
+function calculateDistance({ iconSize, latitude, zoom }) {
     const baseDistance = iconSize * metersPerPixel(latitude, zoom);
-    if (isPoi) {
-        return baseDistance;
-    }
     return zoom > 12 ? baseDistance * 1.5 : baseDistance * 2;
 }
 
@@ -277,10 +258,10 @@ function clusterPlaces(places, zoom, isFavorites) {
     return clustered;
 }
 
-function createMainMarkersArr(clusters, useUniformMarkerPlacement, mainMinDistance, isFavorites, isPoi) {
+function createMainMarkersArr(clusters, useUniformMarkerPlacement, mainMinDistance, isFavorites) {
     const mainMarkers = [];
     if (useUniformMarkerPlacement) {
-        if (!isPoi && !isFavorites) {
+        if (!isFavorites) {
             // Remove images from clusters without icon
             clusters = clusters.map((cluster) => cluster.filter((item) => getImgByProps(item.properties)));
             // Remove empty clusters

--- a/map/src/map/util/Clusterizer.js
+++ b/map/src/map/util/Clusterizer.js
@@ -19,12 +19,6 @@ import { getImgByProps, updateMarkerZIndex } from '../layers/ExploreLayer';
 import { SimpleDotMarker } from '../markers/SimpleDotMarker';
 import { MARKER_Z_INDEX_MAIN } from './ZIndexes';
 
-function getPointLatLon(point) {
-    const lat = point.lat ?? point.ext?.lat;
-    const lon = point.lon ?? point.ext?.lon;
-    return lat != null && lon != null ? { lat: lat, lon: lon } : null;
-}
-
 export const EXPLORE_BIG_ICON_SIZE = 36;
 export const EXPLORE_BIG_REAL_ICON_SIZE = 42;
 export const SIMPLE_ICON_SIZE = 10;
@@ -144,7 +138,7 @@ function createExploreMarkersArr({ places, mainMinDistance, secondaryMinDistance
 }
 
 // POI clustering by screen-pixel radius: big markers take the most popular (elo) place
-// first, greedily kept POI_MAIN_RADIUS_PX apart; the rest become small dots kept POI_SECONDARY_RADIUS_PX
+// first, greedily kept mainRadiusPx apart; the rest become small dots kept secondaryRadiusPx
 // apart. Both passes prevent overlap.
 function createPoiMarkersArr({ places, latitude, zoom, mainRadiusPx, secondaryRadiusPx }) {
     const mpp = metersPerPixel(latitude, zoom);
@@ -210,6 +204,12 @@ const metersPerPixel = (latitude, zoomLevel) => {
     // 256 pixels per tile
     return (earthCircumference * Math.cos(latitudeRad)) / (256 * scale);
 };
+
+function getPointLatLon(point) {
+    const lat = point.lat ?? point.ext?.lat;
+    const lon = point.lon ?? point.ext?.lon;
+    return lat != null && lon != null ? { lat: lat, lon: lon } : null;
+}
 
 // Function to check if a place can be added without overlapping
 const canPlaceMarker = ({ place, existingPlaces, minDistance, isFav = false }) => {

--- a/map/src/map/util/TrackLayerProvider.js
+++ b/map/src/map/util/TrackLayerProvider.js
@@ -450,12 +450,6 @@ function getPointGeoProfile(point, points) {
     }
 }
 
-export function getPointLatLon(point) {
-    const lat = point.lat ?? point.ext?.lat;
-    const lon = point.lon ?? point.ext?.lon;
-    return lat != null && lon != null ? { lat: lat, lon: lon } : null;
-}
-
 // WARNING: Do not use the 'title' field in marker layers on the map
 // When the 'title' attribute is set on a marker, Leaflet automatically creates a default tooltip
 // displaying the 'title' content. This tooltip is hardcoded and cannot be removed or modified

--- a/map/src/util/hooks/useWeatherLocationChange.js
+++ b/map/src/util/hooks/useWeatherLocationChange.js
@@ -1,4 +1,5 @@
 import {
+    dayFormatter,
     fetchDayForecast,
     fetchWeekForecast,
     LOCAL_STORAGE_WEATHER_FORECAST_DAY,
@@ -146,12 +147,6 @@ export const useWeatherLocationChange = ({
                 }
             }
             return false;
-        }
-
-        function dayFormatter(date) {
-            const isoString = date.toISOString();
-            const parts = isoString.split('T')[0].split('-');
-            return parts[1] + parts[2];
         }
 
         let savedWeatherLoc = localStorage.getItem(LOCAL_STORAGE_WEATHER_LOC);

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -55,6 +55,11 @@ module.exports = {
         'geoRouter/geoRouter$': path.join(MAP_DIR, 'src/store/geoRouter/geoRouter.js'),
         // icons and marker shapes are plain svg logic
         'markers/MarkerOptions$': path.join(MAP_DIR, 'src/map/markers/MarkerOptions.js'),
+        // marker clustering is plain geometry over the places, no map is involved
+        'map/util/Clusterizer$': path.join(MAP_DIR, 'src/map/util/Clusterizer.js'),
+        // map layers and the tooltip helper reach react-leaflet, the clustering geometry does not
+        '/MapManager$': `${STUBS}/empty.js`,
+        'layers/(FavoriteLayer|ExploreLayer)$': `${STUBS}/empty.js`,
         // UI layers - unit tests cover managers, not components
         '/(menu|frame|infoblock|dialogs)/': `${STUBS}/empty.js`,
         '/map/(layers|util|markers)/': `${STUBS}/empty.js`,

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -60,6 +60,8 @@ module.exports = {
         // map layers and the tooltip helper reach react-leaflet, the clustering geometry does not
         '/MapManager$': `${STUBS}/empty.js`,
         'layers/(FavoriteLayer|ExploreLayer)$': `${STUBS}/empty.js`,
+        // rebuilding the favorite groups after a change is plain logic over the server response
+        'favorite/FavoriteHelper$': path.join(MAP_DIR, 'src/infoblock/components/favorite/FavoriteHelper.js'),
         // UI layers - unit tests cover managers, not components
         '/(menu|frame|infoblock|dialogs)/': `${STUBS}/empty.js`,
         '/map/(layers|util|markers)/': `${STUBS}/empty.js`,

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
         '\\.(svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|eot|ttf|otf|mp3|mp4|wav)$': `${STUBS}/file.js`,
         // no unit test is allowed to reach the network
         HttpApi$: `${STUBS}/httpApi.js`,
-        // the local tracks storage is real: its tests install an indexedDB fake, the others never call it
+        // the local tracks storage is real: setup.js gives every suite an in-memory indexedDB fake
         'context/LocalTrackStorage$': path.join(MAP_DIR, 'src/context/LocalTrackStorage.js'),
         // AppContext pulls in the whole app - only the track-type helpers are needed
         'context/AppContext$': `${STUBS}/appContext.js`,

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -29,9 +29,10 @@ module.exports = {
         // static assets
         '\\.(css|less|sass|scss)$': `${STUBS}/style.js`,
         '\\.(svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|eot|ttf|otf|mp3|mp4|wav)$': `${STUBS}/file.js`,
-        // no unit test is allowed to reach the network or IndexedDB
+        // no unit test is allowed to reach the network
         HttpApi$: `${STUBS}/httpApi.js`,
-        LocalTrackStorage$: `${STUBS}/localTrackStorage.js`,
+        // the local tracks storage is real: its tests install an indexedDB fake, the others never call it
+        'context/LocalTrackStorage$': path.join(MAP_DIR, 'src/context/LocalTrackStorage.js'),
         // AppContext pulls in the whole app - only the track-type helpers are needed
         'context/AppContext$': `${STUBS}/appContext.js`,
         // modules pulling map layers / routing / i18n - not exercised by unit tests

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -31,8 +31,6 @@ module.exports = {
         '\\.(svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|eot|ttf|otf|mp3|mp4|wav)$': `${STUBS}/file.js`,
         // no unit test is allowed to reach the network
         HttpApi$: `${STUBS}/httpApi.js`,
-        // the local tracks storage is real: setup.js gives every suite an in-memory indexedDB fake
-        'context/LocalTrackStorage$': path.join(MAP_DIR, 'src/context/LocalTrackStorage.js'),
         // AppContext pulls in the whole app - only the track-type helpers are needed
         'context/AppContext$': `${STUBS}/appContext.js`,
         // modules pulling map layers / routing / i18n - not exercised by unit tests

--- a/tests/unit/jest.config.js
+++ b/tests/unit/jest.config.js
@@ -50,6 +50,8 @@ module.exports = {
         'menu/share/shareConstants$': path.join(MAP_DIR, 'src/menu/share/shareConstants.js'),
         // unit conversion is plain math used by the poi tags
         'units/UnitsConverter$': path.join(MAP_DIR, 'src/menu/settings/units/UnitsConverter.js'),
+        // the router profiles and their params are plain logic over the loaded providers
+        'geoRouter/geoRouter$': path.join(MAP_DIR, 'src/store/geoRouter/geoRouter.js'),
         // icons and marker shapes are plain svg logic
         'markers/MarkerOptions$': path.join(MAP_DIR, 'src/map/markers/MarkerOptions.js'),
         // UI layers - unit tests cover managers, not components

--- a/tests/unit/src/tests/favorites/00-fav-groups.test.js
+++ b/tests/unit/src/tests/favorites/00-fav-groups.test.js
@@ -10,7 +10,7 @@ import FavoritesManager, {
     normalizeFavoritePointsGroupName,
     normalizeGroupNameForFile,
 } from '@map/manager/FavoritesManager';
-import { fakeTracksDb } from '../../util/indexedDb';
+import { fakeIndexedDbStore } from '../../util/indexedDb';
 
 const t = (key) => key;
 
@@ -56,7 +56,7 @@ describe('groups restored from the cache', () => {
                 { name: groups[i].name, pointsGroups: { [groups[i].name]: groups[i].pointsGroup } },
             ])
         );
-        fakeTracksDb(records);
+        fakeIndexedDbStore(records);
 
         return favGroups;
     }

--- a/tests/unit/src/tests/favorites/00-fav-groups.test.js
+++ b/tests/unit/src/tests/favorites/00-fav-groups.test.js
@@ -1,0 +1,123 @@
+import FavoritesManager, {
+    addFavGroupsToMap,
+    addLocDist,
+    createFavGroupFreeName,
+    decodeGroupNameFromFile,
+    extractBaseFavFileName,
+    getFavGroupKey,
+    getFavMenuListByLayers,
+    getSize,
+    normalizeFavoritePointsGroupName,
+    normalizeGroupNameForFile,
+} from '@map/manager/FavoritesManager';
+import { fakeTracksDb } from '../../util/indexedDb';
+
+const t = (key) => key;
+
+function favFile(name, updatetimems = 1000) {
+    return { name: `favorites-${name}.gpx`, type: 'FAVOURITES', userid: 1, updatetimems };
+}
+
+describe('group names', () => {
+    test('a group name travels to the file name and back', () => {
+        const groupName = 'Trips/Alps: 2026';
+        const inFileName = normalizeGroupNameForFile(groupName);
+
+        expect(inFileName).toBe('Trips_%_Alps_-_ 2026');
+        expect(decodeGroupNameFromFile(inFileName)).toBe(groupName);
+        expect(extractBaseFavFileName(`favorites-${inFileName}.gpx`)).toBe(inFileName);
+        // the default group is kept under an empty name inside the file
+        expect(normalizeFavoritePointsGroupName(FavoritesManager.DEFAULT_GROUP_NAME)).toBe('');
+        expect(normalizeFavoritePointsGroupName(groupName)).toBe(groupName);
+    });
+
+    test('a new group gets a free name', () => {
+        const groups = [{ name: 'Trips' }, { name: 'Trips - 1' }];
+
+        expect(createFavGroupFreeName('Alps', groups)).toBe('Alps');
+        expect(createFavGroupFreeName('Trips', groups)).toBe('Trips - 2');
+        expect(createFavGroupFreeName('Trips', null)).toBe('Trips');
+
+        const occupied = Array.from({ length: 100 }, (_, i) => ({ name: i === 0 ? 'Trips' : `Trips - ${i}` }));
+        expect(() => createFavGroupFreeName('Trips', occupied)).toThrow();
+    });
+});
+
+describe('groups restored from the cache', () => {
+    function cached(groups) {
+        const files = groups.map((g) => favFile(normalizeGroupNameForFile(g.name)));
+        const favGroups = {
+            groups: files.map((file) => FavoritesManager.createGroup(file)),
+            mapObjs: {},
+        };
+        const records = new Map(
+            favGroups.groups.map((group, i) => [
+                getFavGroupKey(group),
+                { name: groups[i].name, pointsGroups: { [groups[i].name]: groups[i].pointsGroup } },
+            ])
+        );
+        fakeTracksDb(records);
+
+        return favGroups;
+    }
+
+    test('the hidden and pinned flags are read for the group the file holds', async () => {
+        const favGroups = cached([
+            { name: 'Trips/Alps', pointsGroup: { hidden: true, pinned: true } },
+            { name: 'Old', pointsGroup: { points: [{ ext: { extensions: { hidden: 'true' } } }, { ext: {} }] } },
+            { name: 'Visible', pointsGroup: { points: [{ ext: {} }] } },
+            { name: 'personal', pointsGroup: {} },
+        ]);
+
+        const res = await addFavGroupsToMap(favGroups);
+
+        expect(res.groups.map((g) => g.hidden)).toEqual(['true', 'true', 'false', 'false']);
+        expect(res.mapObjs[res.groups[0].id].hidden).toBe('true');
+        expect(res.groups.map((g) => g.pinned)).toEqual([true, undefined, undefined, true]);
+    });
+});
+
+describe('the favorites of a group in the menu', () => {
+    const wpts = [
+        { name: 'Hut', category: 'Trips' },
+        { name: 'Peak', category: 'Trips', color: '#ff0000' },
+    ];
+    const pointsGroups = { Trips: { color: '#00ff00' } };
+    const layers = {
+        1: { options: { name: 'Hut' }, _latlng: { lat: 50, lng: 30 } },
+        2: { options: { name: 'Peak' }, _latlng: { lat: 50.01, lng: 30 } },
+        3: { options: { name: 'Deleted' }, _latlng: { lat: 50, lng: 30 } },
+        4: { options: {} },
+    };
+
+    test('only the waypoints of the group are listed, with the distance to the current location', () => {
+        const list = getFavMenuListByLayers({ layers, wpts, currentLoc: { lat: 50, lng: 30 }, pointsGroups });
+
+        expect(list.map((m) => m.name)).toEqual(['Hut', 'Peak']);
+        expect(list.map((m) => m.locDist)).toEqual(['0', '1112']);
+        // the color of the group is used until the waypoint has its own
+        expect(list.map((m) => m.color)).toEqual(['#00ff00', '#ff0000']);
+        expect(list[0].icon).toContain('svg');
+    });
+
+    test('without a location the list is left as it is', () => {
+        const list = getFavMenuListByLayers({ layers, wpts, currentLoc: null, pointsGroups });
+
+        expect(list.map((m) => m.locDist)).toEqual([undefined, undefined]);
+        expect(addLocDist({ location: null, wpts })).toBe(wpts);
+    });
+});
+
+describe('the size of a group', () => {
+    const group = (name, pointsGroup) => ({ name, pointsGroups: { [name]: pointsGroup } });
+
+    test('the size comes from the group, or from the points it holds', () => {
+        expect(FavoritesManager.getGroupSize(group('Trips', { groupSize: '5' }))).toBe(5);
+        expect(FavoritesManager.getGroupSize(group('Trips', { points: [{}, {}] }))).toBe(2);
+        expect(FavoritesManager.getGroupSize(group('Trips', {}))).toBe(0);
+        expect(FavoritesManager.getGroupSize({ name: 'Trips' })).toBe(0);
+
+        expect(getSize(group('Trips', { groupSize: '5' }), t)).toBe('5 shared_string_gpx_points');
+        expect(getSize(group('Trips', {}), t)).toBe('empty');
+    });
+});

--- a/tests/unit/src/tests/favorites/01-fav-changes.test.js
+++ b/tests/unit/src/tests/favorites/01-fav-changes.test.js
@@ -1,0 +1,110 @@
+import { prepareResult, updateFavoriteGroups } from '@map/manager/FavoritesManager';
+import FavoriteHelper from '@map/infoblock/components/favorite/FavoriteHelper';
+import { getUniqFileId } from '@map/manager/GlobalManager';
+
+const file = (name) => ({ name: `favorites-${name}.gpx`, type: 'FAVOURITES', userid: 1, updatetimems: 1000 });
+
+function group(name, extra = {}) {
+    const f = file(name);
+    return { id: getUniqFileId(f), name, file: f, updatetimems: 1000, pointsGroups: {}, ...extra };
+}
+
+const resp = (trackData, times = {}) => ({
+    clienttime: times.clienttime ?? 2000,
+    updatetime: times.updatetime ?? 3000,
+    details: { trackData },
+});
+
+function ctxWith(groups, mapObjs = {}) {
+    return {
+        favorites: { groups, mapObjs },
+        setUpdateMarkers: jest.fn(),
+        setFavorites: jest.fn(),
+    };
+}
+
+test('the server response is unpacked into the new and the old group', () => {
+    const withNaN = '{"wpts":[{"name":"Hut","ele":NaN}]}';
+
+    const res = prepareResult({ data: { respNewGroup: resp(withNaN), respOldGroup: '' } });
+
+    expect(res.newGroupResp).toEqual({
+        clienttimems: 2000,
+        updatetimems: 3000,
+        data: { wpts: [{ name: 'Hut', ele: null }] },
+    });
+    expect(res.oldGroupResp).toBeNull();
+    expect(prepareResult({})).toBeUndefined();
+});
+
+test('a favorite moved to another group updates both groups and leaves the rest alone', () => {
+    const groups = [group('Trips', { pinned: true }), group('Alps'), group('Cities')];
+    const ctx = ctxWith(groups);
+    const result = {
+        newGroupResp: {
+            clienttimems: 2000,
+            updatetimems: 3000,
+            data: { pointsGroups: { Alps: {} }, wpts: [{ hidden: 'true' }] },
+        },
+        oldGroupResp: { clienttimems: 2500, updatetimems: 3500, data: { pointsGroups: { Trips: {} }, wpts: [] } },
+    };
+
+    updateFavoriteGroups({ result, selectedGroupId: groups[1].id, oldGroupId: groups[0].id, ctx });
+
+    const [trips, alps, cities] = ctx.favorites.groups;
+    expect(trips.updatetimems).toBe(3500);
+    expect(trips.pointsGroups).toEqual({ Trips: {} });
+    expect(trips.pinned).toBe(true); // the pin of a group survives a change of its favorites
+    expect(trips.hidden).toBeUndefined(); // an empty group is not hidden
+    expect(alps.updatetimems).toBe(3000);
+    expect(alps.hidden).toBe('true');
+    expect(cities).toBe(groups[2]);
+    expect(ctx.setUpdateMarkers).toHaveBeenCalled();
+});
+
+test('the map object of a group is updated, and created when the group was never on the map', () => {
+    const groups = [group('Trips')];
+    const markers = { layers: 1 };
+    const ctx = ctxWith(groups, { [groups[0].id]: { name: 'Trips', markers, wpts: [], updatetimems: 1000 } });
+    const result = {
+        newGroupResp: { clienttimems: 2000, updatetimems: 3000, data: { wpts: [{ hidden: 'true' }] } },
+        oldGroupResp: null,
+    };
+
+    updateFavoriteGroups({ result, selectedGroupId: groups[0].id, ctx });
+
+    const updated = ctx.favorites.mapObjs[groups[0].id];
+    expect(updated.updatetimems).toBe(3000);
+    expect(updated.hidden).toBe('true');
+    expect(updated.markers).toBeUndefined(); // the markers are rebuilt from the new data
+    expect(updated.oldMarkers).toBeDefined();
+
+    const empty = ctxWith(groups);
+    updateFavoriteGroups({ result, selectedGroupId: groups[0].id, ctx: empty });
+
+    const created = empty.favorites.mapObjs[groups[0].id];
+    expect(created.updatetimems).toBe(3000);
+    expect(created.url).toContain(encodeURIComponent('favorites-Trips.gpx'));
+});
+
+test('a group missing from the list is added by the response', () => {
+    const favorites = { groups: [group('Trips')], mapObjs: {} };
+    const result = { clienttimems: 2000, updatetimems: 3000, data: { pointsGroups: { Alps: {} }, wpts: [] } };
+
+    const res = FavoriteHelper.updateSelectedGroup({ favorites, selectedGroupName: 'Alps', result, id: 'no-such-id' });
+
+    const added = res.groups[1];
+    expect(added.name).toBe('Alps');
+    expect(added.file.name).toBe('Alps.gpx');
+    expect(added.id).toBe(getUniqFileId(added.file));
+    expect(added.pointsGroups).toEqual({ Alps: {} });
+
+    const known = FavoriteHelper.updateSelectedGroup({
+        favorites,
+        selectedGroupName: 'Trips',
+        result,
+        id: favorites.groups[0].id,
+    });
+    expect(known.groups).toHaveLength(2);
+    expect(known.groups[0].updatetimems).toBe(3000);
+});

--- a/tests/unit/src/tests/favorites/01-fav-changes.test.js
+++ b/tests/unit/src/tests/favorites/01-fav-changes.test.js
@@ -95,9 +95,8 @@ test('a group missing from the list is added by the response', () => {
 
     const added = res.groups[1];
     expect(added.name).toBe('Alps');
-    expect(added.file.name).toBe('Alps.gpx');
-    expect(added.id).toBe(getUniqFileId(added.file));
     expect(added.pointsGroups).toEqual({ Alps: {} });
+    expect(added.updatetimems).toBe(3000);
 
     const known = FavoriteHelper.updateSelectedGroup({
         favorites,

--- a/tests/unit/src/tests/markers/01-clusterizer.test.js
+++ b/tests/unit/src/tests/markers/01-clusterizer.test.js
@@ -1,0 +1,119 @@
+import { clusterMarkers } from '@map/map/util/Clusterizer';
+import { POI_ELO } from '@map/infoblock/components/wpt/WptTagsProvider';
+
+const LAT = 0;
+const OFFSET_PX = 40; // keep the places away from the tile border the favorites are clustered by
+const M_PER_DEG = (6371000 * Math.PI) / 180; // leaflet measures distances on a sphere of this radius
+
+// meters per pixel at the equator
+const mpp = (zoom) => 40075017 / (256 * 2 ** zoom);
+
+// a place `px` screen pixels to the east of the zero meridian
+function poi(px, zoom, properties = {}) {
+    return {
+        type: 'Feature',
+        properties,
+        geometry: { type: 'Point', coordinates: [((px + OFFSET_PX) * mpp(zoom)) / M_PER_DEG, LAT] },
+    };
+}
+
+function wpt(px, zoom, name, inExt = false) {
+    const lon = ((px + OFFSET_PX) * mpp(zoom)) / M_PER_DEG;
+    return inExt ? { name, ext: { lat: LAT, lon } } : { name, lat: LAT, lon };
+}
+
+const names = (places) => places.map((p) => p.properties?.[POI_ELO] ?? p.properties?.rowNum ?? p.name);
+
+describe('clusterMarkers: poi', () => {
+    const ZOOM = 14;
+    // by default the big markers are kept 64 px apart, the dots 12 px
+    const places = [
+        poi(0, ZOOM, { [POI_ELO]: 10 }),
+        poi(20, ZOOM, { [POI_ELO]: 100 }),
+        poi(100, ZOOM, { [POI_ELO]: 50 }),
+        poi(105, ZOOM, { [POI_ELO]: 5 }),
+    ];
+
+    test('the most popular place takes the big marker, the ones it covers become dots', () => {
+        const { mainMarkers, secondaryMarkers } = clusterMarkers({ places, zoom: ZOOM, latitude: LAT, isPoi: true });
+
+        // 100 wins over 10 standing 20 px away, 50 is far enough for its own big marker
+        expect(names(mainMarkers)).toEqual([100, 50]);
+        // 10 is 20 px from a big marker - still a dot; 5 is 5 px from one - dropped
+        expect(names(secondaryMarkers)).toEqual([10]);
+    });
+
+    test('the caller can ask for a denser map', () => {
+        const { mainMarkers, secondaryMarkers } = clusterMarkers({
+            places,
+            zoom: ZOOM,
+            latitude: LAT,
+            isPoi: true,
+            mainRadiusPx: 8,
+            secondaryRadiusPx: 4,
+        });
+
+        expect(names(mainMarkers)).toEqual([100, 50, 10]);
+        expect(names(secondaryMarkers)).toEqual([5]);
+    });
+});
+
+describe('clusterMarkers: favorites', () => {
+    test('a waypoint too close to a big marker becomes a dot, one too close to a dot is dropped', () => {
+        const ZOOM = 14; // big markers 15 px apart, dots 3 px
+        const places = [wpt(0, ZOOM, 'a'), wpt(5, ZOOM, 'b', true), wpt(20, ZOOM, 'c'), wpt(21, ZOOM, 'd')];
+
+        const { mainMarkers, secondaryMarkers } = clusterMarkers({
+            places,
+            zoom: ZOOM,
+            latitude: LAT,
+            iconSize: 10,
+            secondaryIconSize: 2,
+            isFavorites: true,
+        });
+
+        expect(names(mainMarkers)).toEqual(['a', 'c']);
+        expect(names(secondaryMarkers)).toEqual(['b']);
+    });
+
+    test('a cluster shows at most three big markers when the whole country is on the screen', () => {
+        const ZOOM = 5;
+        const places = [0, 2, 4, 8].map((px) => wpt(px, ZOOM, 'p' + px));
+
+        const { mainMarkers, secondaryMarkers } = clusterMarkers({
+            places,
+            zoom: ZOOM,
+            latitude: LAT,
+            iconSize: 1,
+            secondaryIconSize: 1,
+            isFavorites: true,
+        });
+
+        expect(names(mainMarkers)).toEqual(['p0', 'p2', 'p4']);
+        expect(names(secondaryMarkers)).toEqual(['p8']);
+    });
+});
+
+describe('clusterMarkers: explore', () => {
+    const ZOOM = 14;
+    const places = [
+        poi(0, ZOOM, { rowNum: 150 }),
+        ...Array.from({ length: 25 }, (_, i) => poi((i + 1) * 200, ZOOM, { rowNum: 24 - i })),
+    ];
+
+    test('the top places take the big markers, at most twenty of them', () => {
+        const given = [...places];
+
+        const { mainMarkers, secondaryMarkers } = clusterMarkers({
+            places: given,
+            zoom: ZOOM,
+            latitude: LAT,
+            isExplore: true,
+        });
+
+        expect(names(mainMarkers)).toEqual(Array.from({ length: 20 }, (_, i) => i));
+        // the place ranked below the first hundred never takes a big marker, the rest become dots
+        expect(names(secondaryMarkers)).toEqual([20, 21, 22, 23, 24, 150]);
+        expect(given).toEqual(places);
+    });
+});

--- a/tests/unit/src/tests/routing/00-router-profiles.test.js
+++ b/tests/unit/src/tests/routing/00-router-profiles.test.js
@@ -1,0 +1,114 @@
+import { geoRouter } from '@map/store/geoRouter/geoRouter';
+
+const OSMAND = {
+    key: 'osmand',
+    type: 'osmand',
+    name: 'OsmAnd Advanced',
+    url: 'https://api.test/routing/route',
+    profiles: [
+        {
+            key: 'car',
+            name: 'Car',
+            params: { short_way: { key: 'short_way', value: false }, avoid: { key: 'avoid', value: 'toll' } },
+            resetParams: { short_way: { key: 'short_way', value: false }, avoid: { key: 'avoid', value: '' } },
+        },
+        { key: 'bicycle', name: 'Bicycle', params: {}, resetParams: {} },
+    ],
+};
+
+const OSRM = {
+    key: 'OSRM',
+    type: 'osrm',
+    name: 'OSRM',
+    url: 'https://osrm.test/route/v1/',
+    profiles: [
+        { key: 'OSRM-car', name: 'Car', url: 'https://osrm.test/route/v1/driving/' },
+        { key: 'OSRM-bike', name: 'Bike' },
+    ],
+};
+
+/** The router as it is after the providers are loaded: osmand is current. */
+function router() {
+    const geo = new geoRouter();
+    geo.providers = [OSMAND, OSRM];
+    geo.colors = { car: 'blue' };
+    geo.loaded = true;
+
+    return geo;
+}
+
+describe('getProfile', () => {
+    test('a profile is described by the provider it belongs to', () => {
+        const geo = router();
+
+        expect(geo.getProfile()).toMatchObject({
+            key: 'car',
+            name: 'Car',
+            color: 'blue',
+            type: 'osmand',
+            router: 'osmand',
+            profile: 'car',
+        });
+        expect(geo.getProfile({ geoProfile: { type: 'osrm', router: 'OSRM', profile: 'OSRM-bike' } })).toMatchObject({
+            key: 'OSRM-bike',
+            color: 'black',
+            router: 'OSRM',
+        });
+    });
+
+    test('a profile or a provider that is gone falls back to an existing one', () => {
+        const geo = router();
+
+        expect(geo.getProfile({ router: 'OSRM', profile: 'OSRM-scooter' })).toMatchObject({
+            key: 'OSRM-car',
+            router: 'OSRM',
+        });
+        expect(geo.getProfile({ router: 'gone', profile: 'car' })).toMatchObject({ router: 'osmand' });
+    });
+});
+
+describe('the profile of a track point', () => {
+    test('the profile is stored with a cache key of everything it depends on', () => {
+        const geo = router().getGeoProfile();
+
+        expect(geo).toMatchObject({ type: 'osmand', router: 'osmand', profile: 'car' });
+        expect(geo.cacheKey).toBe(
+            'osmand_osmand_car_{"short_way":{"key":"short_way","value":false},"avoid":{"key":"avoid","value":"toll"}}'
+        );
+    });
+
+    test('the short profile keeps only the key and the value of every param', () => {
+        expect(router().getShortGeoProfile().params).toEqual({
+            short_way: { key: 'short_way', value: false },
+            avoid: { key: 'avoid', value: 'toll' },
+        });
+        expect(router().getGeoProfile({ profile: 'bicycle' }).params).toEqual({});
+    });
+});
+
+describe('the params of a profile', () => {
+    test('the caller gets a copy, the provider is not changed by it', () => {
+        const geo = router();
+
+        const params = geo.getParams();
+        params.short_way.value = true;
+
+        expect(geo.getParams().short_way.value).toBe(false);
+    });
+
+    test('only the params that differ from their reset value are a change', () => {
+        const geo = router();
+
+        expect(Object.keys(geo.getChangedParams())).toEqual(['avoid']);
+        expect(geo.isParamsChanged({ params: geo.getResetParams() })).toBe(false);
+        expect(geo.isParamsChanged({ params: geo.getParams() })).toBe(true);
+    });
+});
+
+test('the url of the profile wins over the url of its provider', () => {
+    const geo = router();
+
+    expect(geo.getURL({ router: 'OSRM', profile: 'OSRM-car' })).toBe('https://osrm.test/route/v1/driving/');
+    expect(geo.getURL({ router: 'OSRM', profile: 'OSRM-bike' })).toBe('https://osrm.test/route/v1/');
+    expect(geo.getURL()).toBe('https://api.test/routing/route');
+});

--- a/tests/unit/src/tests/tracks/12-track-editor.test.js
+++ b/tests/unit/src/tests/tracks/12-track-editor.test.js
@@ -1,0 +1,129 @@
+import TracksManager, {
+    addDistanceToPoints,
+    isPointUnrouted,
+    isProtectedSegment,
+    splitProtectedSegment,
+    validateRoutePoints,
+    PROFILE_LINE,
+} from '@map/manager/track/TracksManager';
+
+const GAP = TracksManager.PROFILE_GAP;
+
+/** Geometry of a routed segment: the points the router returned between two track points. */
+function geometry(...coords) {
+    return coords.map(([lat, lng]) => ({ lat, lng }));
+}
+
+describe('what the editor may change', () => {
+    test('a point is routed when it has a profile and a geometry', () => {
+        const point = { profile: 'car', geometry: geometry([50, 30], [50.1, 30.1]) };
+
+        expect(isPointUnrouted({ point, pointIndex: 1, prevPoint: {} })).toBe(false);
+        expect(isPointUnrouted({ point: { geometry: [] }, pointIndex: 1, prevPoint: {} })).toBe(true);
+        expect(isPointUnrouted({ point: { profile: 'car' }, pointIndex: 1, prevPoint: {} })).toBe(true);
+    });
+
+    test('an empty geometry is routed for the first point and after a gap', () => {
+        const point = { profile: 'car', geometry: [] };
+
+        expect(isPointUnrouted({ point, pointIndex: 0, prevPoint: null })).toBe(false);
+        expect(isPointUnrouted({ point, pointIndex: 1, prevPoint: { profile: GAP } })).toBe(false);
+        expect(isPointUnrouted({ point, pointIndex: 1, prevPoint: { profile: 'car' } })).toBe(true);
+    });
+
+    test('a routed segment can be changed, the others are protected', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const routed = { geometry: geometry([50, 30], [50.1, 30.1], [50.2, 30.2]) };
+
+        expect(isProtectedSegment({ startPoint: { profile: 'car' }, endPoint: routed })).toBe(false);
+        // a plain point-to-point line is not protected either
+        expect(
+            isProtectedSegment({ startPoint: { profile: PROFILE_LINE }, endPoint: { geometry: geometry([50, 30]) } })
+        ).toBe(false);
+
+        expect(isProtectedSegment({ startPoint: {}, endPoint: {} })).toBe(true);
+        expect(isProtectedSegment({ startPoint: { profile: PROFILE_LINE }, endPoint: routed })).toBe(true);
+        expect(isProtectedSegment({ startPoint: { profile: GAP }, endPoint: { geometry: [] } })).toBe(true);
+        expect(isProtectedSegment({ startPoint: null, endPoint: {} })).toBe(true);
+    });
+});
+
+describe('splitProtectedSegment', () => {
+    function track() {
+        return [
+            { lat: 50, lng: 30, profile: 'car', geometry: [] },
+            {
+                lat: 50.3,
+                lng: 30.3,
+                profile: 'car',
+                geometry: geometry([50, 30], [50.1, 30.1], [50.2, 30.2], [50.3, 30.3]),
+            },
+        ];
+    }
+
+    test('the geometry is cut in two and the new point is inserted between them', () => {
+        const trackPoints = track();
+        const newPoint = { lat: 50.15, lng: 30.15 };
+
+        splitProtectedSegment({ newPoint, trackPoints, geometryIndex: 1, endPointIndex: 1 });
+
+        expect(trackPoints.map((p) => [p.lat, p.lng])).toEqual([
+            [50, 30],
+            [50.15, 30.15],
+            [50.3, 30.3],
+        ]);
+        expect(newPoint.geometry).toEqual(geometry([50, 30], [50.1, 30.1], [50.15, 30.15]));
+        expect(newPoint.profile).toBe('car');
+        expect(trackPoints[2].geometry).toEqual(geometry([50.15, 30.15], [50.2, 30.2], [50.3, 30.3]));
+    });
+
+    test('a part that becomes a plain line keeps a doubled point, a miss changes nothing', () => {
+        const trackPoints = track();
+        const newPoint = { lat: 50.05, lng: 30.05 };
+
+        splitProtectedSegment({ newPoint, trackPoints, geometryIndex: 0, endPointIndex: 1 });
+        expect(newPoint.geometry).toEqual(geometry([50, 30], [50.05, 30.05], [50.05, 30.05]));
+
+        const untouched = track();
+        splitProtectedSegment({
+            newPoint: { lat: 1, lng: 1 },
+            trackPoints: untouched,
+            geometryIndex: -1,
+            endPointIndex: 1,
+        });
+        expect(untouched).toHaveLength(2);
+    });
+});
+
+describe('the points that go to the router', () => {
+    test('plain points are taken as they are, an already routed track is not overwritten', () => {
+        expect(
+            validateRoutePoints([
+                { lat: 50, lng: 30 },
+                { lat: 50.1, lng: 30.1 },
+            ])
+        ).toBe(true);
+        expect(validateRoutePoints([])).toBe(false);
+        expect(validateRoutePoints([{ geometry: geometry([50, 30], [50.1, 30.1]) }, { geometry: [] }])).toBe(false);
+    });
+
+    test('a gap of a routed track is kept, the last point gets it', () => {
+        const points = [{ geometry: [] }, { profile: GAP }];
+
+        expect(validateRoutePoints(points)).toBe(true);
+        expect(points[points.length - 1].profile).toBe(GAP);
+    });
+});
+
+test('every point carries the length of its segment and of the track, a gap starts a new segment', () => {
+    // the gap is marked on the last point of the geometry, not on the track point
+    const gapGeometry = geometry([50, 30], [50, 30.1]);
+    gapGeometry[gapGeometry.length - 1].profile = GAP;
+    const points = [{ geometry: gapGeometry }, { geometry: geometry([50, 30.1], [50, 30.2]) }];
+
+    addDistanceToPoints(points);
+
+    expect(points[0].dist).toBeGreaterThan(0);
+    expect(points[1].distanceSegment).toBe(points[1].dist);
+    expect(points[1].distanceTotal).toBeCloseTo(points[0].dist + points[1].dist, 1);
+});

--- a/tests/unit/src/tests/tracks/13-local-tracks.test.js
+++ b/tests/unit/src/tests/tracks/13-local-tracks.test.js
@@ -1,0 +1,102 @@
+import {
+    deleteLocalTrack,
+    deleteLocalTracksByIndexes,
+    loadLocalTracksFromStorage,
+    saveTrackToLocalStorage,
+} from '@map/context/LocalTrackStorage';
+import { fakeTracksDb, removeIndexedDb } from '../../util/indexedDb';
+
+/** ctx as the local tracks menu keeps it: the list itself plus its setter. */
+function createCtx(localTracks = []) {
+    const ctx = {
+        localTracks,
+        setLocalTracks: jest.fn((update) => {
+            ctx.localTracks = typeof update === 'function' ? update(ctx.localTracks) : update;
+        }),
+        setRoutingErrorMsg: jest.fn(),
+    };
+
+    return ctx;
+}
+
+function track(name) {
+    return { name, points: [{ lat: 50, lng: 30 }], wpts: [] };
+}
+
+/** the storage writes are not awaited by the app, give them a tick */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+let db;
+
+beforeEach(() => {
+    db = fakeTracksDb();
+});
+
+afterEach(() => {
+    removeIndexedDb();
+});
+
+test('a track is saved under its own place, a nameless one is refused', async () => {
+    const ctx = createCtx();
+
+    saveTrackToLocalStorage({ ctx, track: track('Track') });
+    saveTrackToLocalStorage({ ctx, track: { ...track('Track'), points: [{ lat: 51, lng: 31 }] } });
+    saveTrackToLocalStorage({ ctx, track: { points: [] } });
+    await settle();
+
+    expect(ctx.localTracks.map((t) => t.name)).toEqual(['Track']);
+    expect([...db.keys()]).toEqual([0]);
+    expect(db.get(0).points).toEqual([{ lat: 51, lng: 31 }]);
+    expect(ctx.setRoutingErrorMsg).toHaveBeenCalled();
+});
+
+test('the tracks are loaded in the order of their ids, a record without a name is dropped', async () => {
+    db.set(2, track('Third'));
+    db.set(0, track('First'));
+    db.set(1, { points: [] });
+
+    const tracks = await loadLocalTracksFromStorage(jest.fn());
+
+    expect(tracks.map((t) => t.name)).toEqual(['First', 'Third']);
+    // the ids are packed again, so the next save does not overwrite anybody
+    expect([...db.entries()].map(([id, t]) => [id, t.name])).toEqual([
+        [0, 'First'],
+        [1, 'Third'],
+    ]);
+});
+
+describe('deleting local tracks', () => {
+    function ctxWithThree() {
+        ['First', 'Second', 'Third'].forEach((name, id) => db.set(id, track(name)));
+
+        return createCtx([track('First'), track('Second'), track('Third')]);
+    }
+
+    test('a track deleted in the same session does not come back after a reload', async () => {
+        const ctx = ctxWithThree();
+
+        deleteLocalTrack(ctx, 1);
+        await settle();
+        ctx.selectedGpxFile = track('Third');
+        deleteLocalTrack(ctx);
+        await settle();
+
+        expect(ctx.localTracks.map((t) => t.name)).toEqual(['First']);
+        const left = await loadLocalTracksFromStorage(jest.fn());
+        expect(left.map((t) => t.name)).toEqual(['First']);
+    });
+
+    test('the tracks that are left keep their place in the storage', async () => {
+        const ctx = ctxWithThree();
+
+        deleteLocalTracksByIndexes(ctx, [0]);
+        await settle();
+        expect(ctx.localTracks.map((t) => t.name)).toEqual(['Second', 'Third']);
+        expect((await loadLocalTracksFromStorage(jest.fn())).map((t) => t.name)).toEqual(['Second', 'Third']);
+
+        const other = ctxWithThree();
+        deleteLocalTracksByIndexes(other, [0, 2]);
+        await settle();
+        expect((await loadLocalTracksFromStorage(jest.fn())).map((t) => t.name)).toEqual(['Second']);
+    });
+});

--- a/tests/unit/src/tests/tracks/13-local-tracks.test.js
+++ b/tests/unit/src/tests/tracks/13-local-tracks.test.js
@@ -4,7 +4,7 @@ import {
     loadLocalTracksFromStorage,
     saveTrackToLocalStorage,
 } from '@map/context/LocalTrackStorage';
-import { fakeTracksDb, removeIndexedDb } from '../../util/indexedDb';
+import { fakeIndexedDbStore, removeIndexedDb } from '../../util/indexedDb';
 
 /** ctx as the local tracks menu keeps it: the list itself plus its setter. */
 function createCtx(localTracks = []) {
@@ -29,7 +29,7 @@ const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 let db;
 
 beforeEach(() => {
-    db = fakeTracksDb();
+    db = fakeIndexedDbStore();
 });
 
 afterEach(() => {

--- a/tests/unit/src/tests/weather/00-weather.test.js
+++ b/tests/unit/src/tests/weather/00-weather.test.js
@@ -1,0 +1,78 @@
+import {
+    dayFormatter,
+    ECWMF_WEATHER_TYPE,
+    GFS_WEATHER_TYPE,
+    getAlignedStep,
+    getBaseStep,
+    getSavedWeekForecast,
+    LOCAL_STORAGE_WEATHER_FORECAST_WEEK,
+    timeFormatter,
+} from '@map/manager/WeatherManager';
+
+const gfs = { weatherType: GFS_WEATHER_TYPE };
+const ecmwf = { weatherType: ECWMF_WEATHER_TYPE };
+
+test('the forecast row is looked up by the utc day and hour', () => {
+    const date = new Date('2026-09-08T22:00:00Z');
+    date.getDate = () => 9; // east of utc the same moment is already the next day
+
+    expect(`${dayFormatter(date)} ${timeFormatter(date)}`).toBe('0908 22:00');
+});
+
+describe('getBaseStep', () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-09-08T10:00:00Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('the step grows with the distance from now', () => {
+        expect(getBaseStep(23, gfs)).toBe(1);
+        expect(getBaseStep(24, gfs)).toBe(3);
+        // ecmwf counts the five days from the start of the current day, not from now
+        expect(getBaseStep(109, ecmwf)).toBe(3);
+        expect(getBaseStep(110, ecmwf)).toBe(6);
+    });
+});
+
+describe('getAlignedStep', () => {
+    const at = (hoursUTC) => new Date(Date.UTC(2026, 8, 10, hoursUTC));
+    const step = (direction, hoursUTC) =>
+        getAlignedStep({ direction, weatherDate: at(hoursUTC), wtx: gfs, diffHours: 30 }); // 3-hour step
+
+    test('an hour off the grid is pulled onto it, an aligned one moves by a whole step', () => {
+        expect(step(0, 12)).toBe(0);
+        expect(step(0, 13)).toBe(2);
+        expect(step(+1, 12)).toBe(3);
+        expect(step(+1, 13)).toBe(2);
+        expect(step(-1, 12)).toBe(-3);
+        expect(step(-1, 13)).toBe(-1);
+    });
+
+    test('every hour is on the grid while the forecast is hourly', () => {
+        const hourly = (direction) => getAlignedStep({ direction, weatherDate: at(13), wtx: gfs, diffHours: 5 });
+
+        expect(hourly(0)).toBe(0);
+        expect(hourly(+1)).toBe(1);
+        expect(hourly(-1)).toBe(-1);
+    });
+});
+
+describe('getSavedWeekForecast', () => {
+    test('only a saved list of forecast rows is restored', () => {
+        expect(getSavedWeekForecast()).toBeNull();
+
+        const save = (value) => localStorage.setItem(LOCAL_STORAGE_WEATHER_FORECAST_WEEK, value);
+
+        save('not a json');
+        expect(getSavedWeekForecast()).toBeNull();
+
+        save(JSON.stringify([{ temp: 1 }]));
+        expect(getSavedWeekForecast()).toBeNull();
+
+        save(JSON.stringify([{ ts: 1, temp: 1 }]));
+        expect(getSavedWeekForecast()).toEqual([{ ts: 1, temp: 1 }]);
+    });
+});

--- a/tests/unit/src/util/indexedDb.js
+++ b/tests/unit/src/util/indexedDb.js
@@ -16,10 +16,11 @@ export function fakeIndexedDb() {
 }
 
 /**
- * indexedDB fake with one working object store, enough for the local tracks storage.
- * Returns the store itself as a Map of id -> record, to set it up and to read it back.
+ * indexedDB fake with one working object store, enough for the local tracks and the favorites cache.
+ * The name of the database is ignored. Returns the store itself as a Map of id -> record,
+ * to set it up and to read it back.
  */
-export function fakeTracksDb(records = new Map()) {
+export function fakeIndexedDbStore(records = new Map()) {
     // the callers read the result either from the request itself or from the event
     const request = (result) => {
         const req = { result };

--- a/tests/unit/src/util/indexedDb.js
+++ b/tests/unit/src/util/indexedDb.js
@@ -15,6 +15,37 @@ export function fakeIndexedDb() {
     return deleted;
 }
 
+/**
+ * indexedDB fake with one working object store, enough for the local tracks storage.
+ * Returns the store itself as a Map of id -> record, to set it up and to read it back.
+ */
+export function fakeTracksDb(records = new Map()) {
+    // the callers read the result either from the request itself or from the event
+    const request = (result) => {
+        const req = { result };
+        queueMicrotask(() => req.onsuccess?.({ target: { result } }));
+
+        return req;
+    };
+
+    const store = {
+        get: (id) => request({ id, data: records.get(id) }),
+        getAll: () => request([...records.entries()].map(([id, data]) => ({ id, data }))),
+        put: ({ id, data }) => request(records.set(id, data)),
+        delete: (id) => request(records.delete(id)),
+        clear: () => request(records.clear()),
+    };
+
+    const db = {
+        objectStoreNames: { contains: () => true },
+        transaction: () => ({ objectStore: () => store }),
+    };
+
+    global.indexedDB = { open: () => request(db) };
+
+    return records;
+}
+
 export function removeIndexedDb() {
     delete global.indexedDB;
 }

--- a/tests/unit/src/util/setup.js
+++ b/tests/unit/src/util/setup.js
@@ -10,7 +10,7 @@ global.TextDecoder = global.TextDecoder ?? TextDecoder;
 process.env.REACT_APP_USER_API_SITE = 'https://api.test';
 
 // the local tracks storage is real in tests: give every suite an empty in-memory indexedDB,
-// the tests of the storage itself install their own records with fakeTracksDb()
-const { fakeTracksDb } = require('./indexedDb');
+// the tests of the storage itself install their own records with fakeIndexedDbStore()
+const { fakeIndexedDbStore } = require('./indexedDb');
 
-fakeTracksDb();
+fakeIndexedDbStore();

--- a/tests/unit/src/util/setup.js
+++ b/tests/unit/src/util/setup.js
@@ -8,3 +8,9 @@ global.TextDecoder = global.TextDecoder ?? TextDecoder;
 
 // the app builds request urls from this - nothing is ever requested, the host is a placeholder
 process.env.REACT_APP_USER_API_SITE = 'https://api.test';
+
+// the local tracks storage is real in tests: give every suite an empty in-memory indexedDB,
+// the tests of the storage itself install their own records with fakeTracksDb()
+const { fakeTracksDb } = require('./indexedDb');
+
+fakeTracksDb();

--- a/tests/unit/src/util/stubs/localTrackStorage.js
+++ b/tests/unit/src/util/stubs/localTrackStorage.js
@@ -1,7 +1,0 @@
-// IndexedDB is not available in jsdom
-module.exports = {
-    __esModule: true,
-    saveTrackToLocalStorage: jest.fn(),
-    deleteLocalTrack: jest.fn(),
-    loadLocalTracksFromStorage: jest.fn(),
-};


### PR DESCRIPTION
## AI disclaimer

Written with Claude (Cowork, Claude Opus 5), driven by [@alisa911](https://github.com/alisa911). Summary of the requests it worked from, in order:

1. Cover the router profiles and their parameters, then "can it be fewer tests?". `routing/00-router-profiles.test.js` covers `getProfile` and its fallback when a router or a profile is gone, the profile stored on a track point and its short form, the params of a profile and what counts as a change, and that the url of a profile wins over the url of its provider. One oddity found and not fixed: `geoRouter.getURL` (`getters.js:153`) is the only getter without the provider fallback, unreachable from the current callers - recorded in KNOWN_ISSUES.md instead.

2. Cover the rules of the track editor, again asking for fewer tests, and asking whether the add-test skill was used at all. Eight tests in `tracks/12-track-editor.test.js`: which segments the editor may change, `splitProtectedSegment`, and the points that are sent to the router. Grouped per function from the start after that.

3. Cover local tracks. The agent first called a delete path an urgent data-loss bug without checking its callers; the author tested it by hand and saw nothing, and the agent had to admit the path is only reachable from the nameless-track cleanup. Writing the tests then exposed a second, user-reachable bug: `deleteLocalTrack` deleted by an index taken from the in-memory list, and `deleteLocalTracksByIndexes` removed the records it had just written, so a track deleted in one session came back after a reload. Both fixed in `LocalTrackStorage.js`, four tests in `tracks/13-local-tracks.test.js`.

4. Cover marker clustering. Three findings in `Clusterizer.js`: the poi branch introduced in 5daeb7bf6 hardcoded 64/12 px radii and stopped reading `iconSize`, so the travel points that `TravelLayer` had asked to keep 8/4 px apart were thinned to 64 px and the closer ones dropped; explore allowed 21 big markers instead of 20 (`<=`); and the explore branch sorted the array of the caller in place. Fixed with `mainRadiusPx` / `secondaryRadiusPx`, covered by five tests in `markers/01-clusterizer.test.js`. `getPointLatLon` moved from `TrackLayerProvider` to `Clusterizer` (its only user) so the module can be loaded in jest without react-leaflet.

5. Cover weather. `WeatherManager.dayFormatter` built the day of the forecast key from the local date while `timeFormatter` used UTC hours, and the server keys those rows in UTC (`WeatherController`, `SimpleDateFormat("yyyyMMdd_HH")` with the UTC time zone), so for every user whose local date differs from UTC the row was not found or the row of the neighbouring day was shown. Fixed, and the duplicate UTC-correct copy of the same function in `useWeatherLocationChange` removed. Five tests in `weather/00-weather.test.js`.

6. Asked what is left to cover in favorites and whether tests are needed there at all; the agent proposed a list and the author picked it up. Six tests in `favorites/00-fav-groups.test.js` (group name to file name and back, a free name for a new group, hidden and pinned restored from the IndexedDB cache, the menu list with distances, the size of a group). A suspected bug - the escaped group name passed to `addHidden` - was disproved by a mutation check and reported as not a bug; `isHidden` reading `point.ext.extensions.hidden` without optional chaining was guarded, as everywhere else in the project.

7. Cover the rebuild of the groups after a favorite changes. Four tests in `favorites/01-fav-changes.test.js` over `prepareResult`, `updateGroupAfterChange` and `updateSelectedGroup`. The second suspicion from the previous item - `updateFavFile` copying every key of the response into `group.file` - was checked against the server's `WebGpxParser.TrackData`, which has no `name` field, so the file name and the group id are not affected.

8. Two rounds of review comments applied. From Copilot: `getPointLatLon` unexported, a stale comment in the jest config, and the poi branch of `clusterMarkers` moved above the distance calculations it never used - which let the now-dead `isPoi` parameters go from `calculateDistance`, `getMaxMainPlaces`, `getUseUniformMarkerPlacement` and `createMainMarkersArr`. From the review of this PR, seven points, all confirmed against the code: a test in `01-fav-changes.test.js` pinned broken behaviour - `FavoriteHelper.updateSelectedGroup` builds the file name without the `favorites-` prefix and the id without `userid`, so a group added by that branch can never match the one the server returns - the assertions were dropped and the bug recorded in KNOWN_ISSUES.md; an orphaned stub and a no-op mapping removed from the jest setup; `fakeTracksDb` renamed to `fakeIndexedDbStore` since it also backs the favorites cache; comments restored and updated; and `iconSize` dropped from the three poi callers where it is no longer read.

No commits were made by the agent; every commit was reviewed and made by the author. The 373 unit tests were run by the agent, the selenium suite by the author.