### PR TITLE
Add unit tests

### DIFF
--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -69,6 +69,16 @@ A test earns its place only if the behaviour can break silently and the user wou
 
 A manager or a formatting module is 10-15 tests, not 30.
 
+## Expect what the app should do, not what it does
+
+The expected value comes from the contract, never from running the code and copying the result. Before pinning a value, find where it is decided and check there:
+
+- a file name, a key, a format shared with the phone or the server - read the Android code (`~/osmand/android`, e.g. `FavouritesFileHelper`) or the server (`~/osmand/tools`, e.g. `WebGpxParser`, `MapApiController`) and expect what they produce; a test that pins the web's own encoding proves nothing when the other side disagrees;
+- a value shown to the user - ask whether a person would call it right (a date order, a name with the extension, a lowercase language);
+- a limit - check what it is measured against (255 bytes of the name, or of the name with the prefix and the extension on the phone).
+
+If a suspected bug's test passes on the first run, suspect the test: it compares live references with themselves (snapshot the numbers before the second call), or the fixture is not what the app really holds (`favorites/favorites.gpx` is not a favorite file name). Write down the reason a value is expected when it is not obvious from the name of the test.
+
 ## Look for bugs while writing
 
 Writing the test is the review. Report the bugs first, before describing the tests, and never write a test that blesses broken behaviour.

--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -73,7 +73,7 @@ A manager or a formatting module is 10-15 tests, not 30.
 
 The expected value comes from the contract, never from running the code and copying the result. Before pinning a value, find where it is decided and check there:
 
-- a file name, a key, a format shared with the phone or the server - read the Android code (`~/osmand/android`, e.g. `FavouritesFileHelper`) or the server (`~/osmand/tools`, e.g. `WebGpxParser`, `MapApiController`) and expect what they produce; a test that pins the web's own encoding proves nothing when the other side disagrees;
+- a file name, a key, a format shared with the phone or the server - read the Android code (osmandapp/android, e.g. `FavouritesFileHelper`) or the server (osmandapp/tools, e.g. `WebGpxParser`, `MapApiController`) and expect what they produce; a test that pins the web's own encoding proves nothing when the other side disagrees;
 - a value shown to the user - ask whether a person would call it right (a date order, a name with the extension, a lowercase language);
 - a limit - check what it is measured against (255 bytes of the name, or of the name with the prefix and the extension on the phone).
 

--- a/map/src/context/TracksRoutingCache.js
+++ b/map/src/context/TracksRoutingCache.js
@@ -11,7 +11,7 @@ export function effectControlRouterRequests({ ctx, startedRouterJobs, setStarted
         return false;
     }
 
-    if (startedRouterJobs > MAX_STARTED_ROUTER_JOBS) {
+    if (startedRouterJobs >= MAX_STARTED_ROUTER_JOBS) {
         console.debug('Too many startedRouterJobs', startedRouterJobs);
         return false;
     }

--- a/map/src/manager/PointManager.js
+++ b/map/src/manager/PointManager.js
@@ -70,6 +70,7 @@ async function insertPoint(points, index, point, lengthSum, ctx) {
         if (i + lengthSum === index && point) {
             if (firstPoint) {
                 if (points[i + 1].geometry) {
+                    point.geometry = []; // nothing leads to the first point
                     let newGeometryFromNewPoint = await geoRouter.updateRouteBetweenPoints(ctx, point, points[i + 1]);
                     if (newGeometryFromNewPoint) {
                         points[i + 1].geometry = newGeometryFromNewPoint.points || [];

--- a/map/src/manager/SettingsManager.js
+++ b/map/src/manager/SettingsManager.js
@@ -135,7 +135,7 @@ export async function deleteFile({ file, changes, setChanges }) {
         },
     });
     if (response.status === 200) {
-        changes = changes.filter((f) => f.id !== file.id);
+        changes = deleteVersionsFromMenu({ changes, id: file.id });
         setChanges(changes);
     }
 }
@@ -206,7 +206,8 @@ function deleteVersionsFromMenu({ changes, name = null, id = null }) {
     });
     // a month header stays only while a file of that month follows it
     changes = changes.filter((f, index) => f.type !== 'month' || changes[index + 1]?.type === 'file');
-    return changes;
+    // the last row of a month has no divider below it
+    return changes.map((f, index) => (f.type === 'file' ? { ...f, isLast: changes[index + 1]?.type !== 'file' } : f));
 }
 
 export function formatString(templateString, replacements) {

--- a/map/src/manager/SettingsManager.js
+++ b/map/src/manager/SettingsManager.js
@@ -204,13 +204,8 @@ function deleteVersionsFromMenu({ changes, name = null, id = null }) {
         }
         return true;
     });
-    changes = changes.filter((f, index) => {
-        if (f.type === 'month') {
-            const nextFileIndex = changes.slice(index + 1).findIndex((f) => f.type === 'file');
-            return nextFileIndex !== -1;
-        }
-        return true;
-    });
+    // a month header stays only while a file of that month follows it
+    changes = changes.filter((f, index) => f.type !== 'month' || changes[index + 1]?.type === 'file');
     return changes;
 }
 

--- a/map/src/manager/track/TracksManager.js
+++ b/map/src/manager/track/TracksManager.js
@@ -300,13 +300,16 @@ export function getTrackPoints(track) {
     const processTrackPoints = (trackPoints) => {
         if (!Array.isArray(trackPoints) || trackPoints.length === 0) return [];
 
-        const subPoints = getAllPoints(trackPoints);
-        if (subPoints.length === 0) return [];
+        const allPoints = getAllPoints(trackPoints);
+        if (allPoints.length === 0) return [];
 
-        subPoints.forEach((point) => (point.distanceTotal += distanceOffset));
+        const subPoints =
+            distanceOffset === 0
+                ? allPoints
+                : allPoints.map((point) => ({ ...point, distanceTotal: point.distanceTotal + distanceOffset }));
 
         // Update the distance offset based on the last point
-        distanceOffset = subPoints[subPoints.length - 1]?.distanceTotal ?? distanceOffset;
+        distanceOffset = subPoints.at(-1)?.distanceTotal ?? distanceOffset;
         return subPoints;
     };
 

--- a/map/src/store/geoObject/convert/convertRouteToTrack.js
+++ b/map/src/store/geoObject/convert/convertRouteToTrack.js
@@ -127,10 +127,16 @@ function createAnalysisFromRoute(points, route) {
     let avgElevation = Number.NaN;
     let minElevation = Number.POSITIVE_INFINITY;
     let maxElevation = Number.NEGATIVE_INFINITY;
+    let firstSegment = true;
     points &&
         points.length > 0 &&
-        points.forEach((p) =>
-            p.geometry?.forEach((g) => {
+        points.forEach((p) => {
+            const geometry = p.geometry ?? [];
+            // a segment starts where the previous one ended, count that point once
+            geometry.forEach((g, index) => {
+                if (index === 0 && !firstSegment) {
+                    return;
+                }
                 if (isNonZeroEle(g?.ele) || isNonZeroEle(g?.ext?.ele)) {
                     const ele = isNonZeroEle(g?.ele) ? g.ele : g.ext.ele;
                     minElevation = Math.min(minElevation, ele);
@@ -139,8 +145,11 @@ function createAnalysisFromRoute(points, route) {
                     elevationSum += ele;
                     avgElevation = elevationSum / elevationPoints;
                 }
-            })
-        );
+            });
+            if (geometry.length > 0) {
+                firstSegment = false;
+            }
+        });
     if (elevationPoints > 0) {
         const props = route.features[0].properties;
         return {

--- a/tests/unit/src/tests/navigation/00-route-to-track.test.js
+++ b/tests/unit/src/tests/navigation/00-route-to-track.test.js
@@ -43,7 +43,7 @@ test('the route is cut into segments at its points, the alternatives are left ou
     expect(track.analysis).toEqual({
         minElevation: 100,
         maxElevation: 130,
-        avgElevation: 116,
+        avgElevation: 115, // (100 + 110 + 120 + 130) / 4: the via point is in both segments but counts once
         hasElevationData: true,
         diffElevationUp: 30,
         diffElevationDown: 0,

--- a/tests/unit/src/tests/navigation/00-route-to-track.test.js
+++ b/tests/unit/src/tests/navigation/00-route-to-track.test.js
@@ -1,0 +1,91 @@
+import { convertRouteToTrack } from '@map/store/geoObject/convert/convertRouteToTrack';
+import { NAN_MARKER } from '@map/manager/track/TracksManager';
+
+const line = (coordinates, properties = {}) => ({ geometry: { type: 'LineString', coordinates }, properties });
+const route = (...features) => ({ features });
+const geoProfile = { profile: 'car', cacheKey: 'car' };
+const point = (lat, lng, name) => ({ lat, lng, name });
+
+// lng, lat, ele - as GeoJSON has it
+const LINE = [
+    [30, 50, 100],
+    [30, 50.01, 110],
+    [30, 50.02, 120],
+    [30, 50.03, 130],
+];
+
+function convert({ start, finish, viaPoints = [], features = [line(LINE)] }) {
+    return convertRouteToTrack({
+        id: 1,
+        route: route(...features),
+        trackName: 'Ride',
+        geoProfile,
+        start,
+        finish,
+        viaPoints,
+    });
+}
+
+test('the route is cut into segments at its points, the alternatives are left out', () => {
+    const track = convert({
+        start: point(50, 30, 'Home'),
+        finish: point(50.03, 30, 'Work'),
+        viaPoints: [point(50.0201, 30, 'Shop'), null],
+        features: [line(LINE, { diffElevationUp: 30, diffElevationDown: 0 }), line([[31, 51]], { alternative: true })],
+    });
+
+    expect(track).toMatchObject({ id: 1, name: 'Ride' });
+    expect(track.tracks[0].points).toBe(track.points);
+    expect(track.points.map((p) => p.name)).toEqual(['Home', 'Shop', 'Work']);
+    expect(track.points.map((p) => p.profile)).toEqual(['car', 'car', 'car']);
+    // the via point off the line snaps to the nearest point of the route, the geometry ends there
+    expect(track.points.map((p) => p.geometry.map((g) => g.lat))).toEqual([[], [50, 50.01, 50.02], [50.02, 50.03]]);
+    expect(track.analysis).toEqual({
+        minElevation: 100,
+        maxElevation: 130,
+        avgElevation: 116,
+        hasElevationData: true,
+        diffElevationUp: 30,
+        diffElevationDown: 0,
+    });
+});
+
+test('without its own points the route starts and ends where the line does', () => {
+    const track = convert({ start: null, finish: null });
+
+    expect(track.points.map((p) => [p.lat, p.lng])).toEqual([
+        [50, 30],
+        [50.03, 30],
+    ]);
+    expect(convert({ start: null, finish: null, features: [line([])] })).toBeNull();
+});
+
+test('a missing elevation at the ends of the line is borrowed from the neighbour', () => {
+    const track = convert({
+        start: null,
+        finish: null,
+        features: [
+            line([
+                [30, 50],
+                [30, 50.01, 110],
+                [30, 50.02],
+            ]),
+        ],
+    });
+
+    expect(track.points[1].geometry.map((g) => g.ele)).toEqual([110, 110, 110]);
+    expect(track.points[1].geometry[0].ext).toEqual({ ele: 110, extensions: {} });
+
+    const flat = convert({
+        start: null,
+        finish: null,
+        features: [
+            line([
+                [30, 50],
+                [30, 50.01],
+            ]),
+        ],
+    });
+    expect(flat.points[1].geometry.map((g) => g.ele)).toEqual([NAN_MARKER, NAN_MARKER]);
+    expect(flat.analysis).toEqual({});
+});

--- a/tests/unit/src/tests/routing/01-routing-cache.test.js
+++ b/tests/unit/src/tests/routing/01-routing-cache.test.js
@@ -1,0 +1,162 @@
+import TracksRoutingCache, {
+    debouncer,
+    effectControlRouterRequests,
+    effectRefreshTrackWithRouting,
+    syncTrackWithCache,
+} from '@map/context/TracksRoutingCache';
+import TracksManager from '@map/manager/track/TracksManager';
+import EditablePolyline from '@map/map/util/creator/EditablePolyline';
+
+const geoRouter = {
+    getGeoProfile: (point) => ({ profile: point.profile, cacheKey: `key-${point.profile}` }),
+    getColor: () => '#0000ff',
+};
+
+const point = (lat, profile = 'car') => ({ lat, lng: 30, profile });
+const line = () => ({ setStyle: jest.fn(), setLatLngs: jest.fn(), removeFrom: jest.fn(), options: {} });
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function createCtx(points = []) {
+    const ctx = {
+        routingCache: {},
+        mutateRoutingCache: (update) => update(ctx.routingCache),
+        selectedGpxFile: { points, layers: {} },
+        setSelectedGpxFile: jest.fn(),
+        setProcessRouting: jest.fn(),
+        trackRouter: { ...geoRouter, updateRouteBetweenPoints: jest.fn() },
+    };
+
+    return ctx;
+}
+
+const entries = (ctx) => Object.values(ctx.routingCache);
+
+test('a segment is cached by its points and profile, a protected one is not cached', () => {
+    const ctx = createCtx();
+    const [a, b] = [point(50), point(51)];
+
+    TracksRoutingCache.addRoutingToCache(a, b, null, ctx);
+    expect(entries(ctx)).toEqual([]);
+
+    TracksRoutingCache.addRoutingToCache(a, b, line(), ctx);
+    expect(entries(ctx)).toMatchObject([{ geometry: null, busy: false, geoProfile: { cacheKey: 'key-car' } }]);
+    // the cache keeps copies, a point dragged later does not change the cached segment
+    a.lat = 49;
+    expect(entries(ctx)[0].startPoint.lat).toBe(50);
+
+    entries(ctx)[0].geometry = ['routed'];
+    TracksRoutingCache.addRoutingToCache(point(50), b, line(), ctx);
+    TracksRoutingCache.addRoutingToCache(point(50, 'bike'), b, line(), ctx);
+    expect(entries(ctx).map((e) => e.geometry)).toEqual([['routed'], null]);
+});
+
+test('the router is asked for the segments without geometry, six at a time', async () => {
+    const ctx = createCtx();
+    const setStartedRouterJobs = jest.fn();
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    ctx.trackRouter.updateRouteBetweenPoints.mockResolvedValue({ points: ['routed'] });
+    for (let i = 0; i < 8; i++) {
+        TracksRoutingCache.addRoutingToCache(point(i), point(i + 1), line(), ctx);
+    }
+
+    expect(effectControlRouterRequests({ ctx, startedRouterJobs: 0, setStartedRouterJobs })).toBe(true);
+    expect(ctx.trackRouter.updateRouteBetweenPoints).toHaveBeenCalledTimes(6);
+    expect(entries(ctx).filter((e) => e.busy)).toHaveLength(6);
+
+    // with six requests in flight nothing more is started
+    expect(effectControlRouterRequests({ ctx, startedRouterJobs: 6, setStartedRouterJobs })).toBe(false);
+    expect(ctx.trackRouter.updateRouteBetweenPoints).toHaveBeenCalledTimes(6);
+
+    await flush();
+    expect(
+        entries(ctx)
+            .filter((e) => e.geometry)
+            .map((e) => e.geometry)
+    ).toEqual(Array(6).fill(['routed']));
+});
+
+test('a failed request is not repeated', async () => {
+    const ctx = createCtx();
+    ctx.trackRouter.updateRouteBetweenPoints.mockRejectedValue(new Error('router down'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    TracksRoutingCache.addRoutingToCache(point(50), point(51), line(), ctx);
+
+    effectControlRouterRequests({ ctx, startedRouterJobs: 0, setStartedRouterJobs: jest.fn() });
+    await flush();
+    effectControlRouterRequests({ ctx, startedRouterJobs: 0, setStartedRouterJobs: jest.fn() });
+
+    expect(ctx.trackRouter.updateRouteBetweenPoints).toHaveBeenCalledTimes(1);
+    expect(ctx.setProcessRouting).toHaveBeenLastCalledWith(false);
+});
+
+test('a routed segment goes into the track once, the segments that are gone leave the cache', () => {
+    const [a, b, gap, c, d] = [point(50), point(51), point(52, TracksManager.PROFILE_GAP), point(53), point(54)];
+    const ctx = createCtx([a, b, gap, c, d]);
+    const saveChanges = jest.fn();
+    EditablePolyline.mockImplementation(function () {
+        return { create: () => ({ _latlngs: ['latlng'] }) };
+    });
+    const [ab, gapC, old] = [line(), line(), line()];
+    TracksRoutingCache.addRoutingToCache(a, b, ab, ctx);
+    TracksRoutingCache.addRoutingToCache(gap, c, gapC, ctx);
+    TracksRoutingCache.addRoutingToCache(c, d, line(), ctx);
+    TracksRoutingCache.addRoutingToCache(point(60), point(61), old, ctx);
+    TracksRoutingCache.addRoutingToCache(point(62), point(63), null, ctx);
+    const [abEntry, gapEntry, cdEntry, oldEntry] = entries(ctx);
+    abEntry.geometry = gapEntry.geometry = oldEntry.geometry = ['routed'];
+
+    expect(effectRefreshTrackWithRouting({ ctx, geoRouter, saveChanges })).toBe(true);
+
+    expect(b.geometry).toEqual(['routed']);
+    expect(ab.setLatLngs).toHaveBeenCalledWith(['latlng']);
+    expect(ab.setStyle).toHaveBeenCalledWith({ color: '#0000ff', dashArray: null });
+    expect(abEntry.tempLine).toBeNull();
+    expect(saveChanges).toHaveBeenCalledTimes(1);
+    // a gap is never routed, a segment still waiting for the router is kept
+    expect(c.geometry).toBeUndefined();
+    expect(gapC.setLatLngs).not.toHaveBeenCalled();
+    expect(entries(ctx)).toEqual([abEntry, gapEntry, cdEntry]);
+
+    // a second pass finds nothing new
+    expect(effectRefreshTrackWithRouting({ ctx, geoRouter, saveChanges })).toBe(false);
+    expect(saveChanges).toHaveBeenCalledTimes(1);
+});
+
+test('undo restores the geometry of every segment from the cache and drops the unfinished ones', () => {
+    jest.useFakeTimers();
+    const [a, b, gap, c, d] = [point(50), point(51), point(52, TracksManager.PROFILE_GAP), point(53), point(54)];
+    const ctx = createCtx([a, b, gap, c, d]);
+    const pending = line();
+    TracksRoutingCache.addRoutingToCache(a, b, line(), ctx);
+    TracksRoutingCache.addRoutingToCache(gap, c, line(), ctx);
+    TracksRoutingCache.addRoutingToCache(c, d, pending, ctx);
+    const [abEntry, gapEntry] = entries(ctx);
+    abEntry.geometry = gapEntry.geometry = ['routed'];
+    abEntry.tempLine = gapEntry.tempLine = null;
+
+    syncTrackWithCache({ ctx, track: ctx.selectedGpxFile, geoRouter, debouncerTimer: { current: null } });
+
+    expect(b.geometry).toEqual(['routed']);
+    expect(c.geometry).toBeUndefined();
+    expect(d.geometry).toBeUndefined();
+    expect(pending.removeFrom).toHaveBeenCalledWith(ctx.selectedGpxFile.layers);
+    expect(entries(ctx)).toEqual([abEntry, gapEntry]);
+    jest.useRealTimers();
+});
+
+test('only the last call of a burst runs', () => {
+    jest.useFakeTimers();
+    const timer = { current: null };
+    const calls = [];
+
+    debouncer(() => calls.push(1), timer, 100);
+    jest.advanceTimersByTime(50);
+    debouncer(() => calls.push(2), timer, 100);
+    jest.advanceTimersByTime(99);
+    expect(calls).toEqual([]);
+    jest.advanceTimersByTime(1);
+
+    expect(calls).toEqual([2]);
+    expect(timer.current).toBeNull();
+    jest.useRealTimers();
+});

--- a/tests/unit/src/tests/routing/01-routing-cache.test.js
+++ b/tests/unit/src/tests/routing/01-routing-cache.test.js
@@ -6,34 +6,19 @@ import TracksRoutingCache, {
 } from '@map/context/TracksRoutingCache';
 import TracksManager from '@map/manager/track/TracksManager';
 import EditablePolyline from '@map/map/util/creator/EditablePolyline';
+import { createEditorCtx, createEditorPoint } from '../../util/fixtures/tracks';
 
-const geoRouter = {
-    getGeoProfile: (point) => ({ profile: point.profile, cacheKey: `key-${point.profile}` }),
-    getColor: () => '#0000ff',
-};
-
-const point = (lat, profile = 'car') => ({ lat, lng: 30, profile });
+const point = (i, profile) => createEditorPoint(i, { profile });
 const line = () => ({ setStyle: jest.fn(), setLatLngs: jest.fn(), removeFrom: jest.fn(), options: {} });
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-function createCtx(points = []) {
-    const ctx = {
-        routingCache: {},
-        mutateRoutingCache: (update) => update(ctx.routingCache),
-        selectedGpxFile: { points, layers: {} },
-        setSelectedGpxFile: jest.fn(),
-        setProcessRouting: jest.fn(),
-        trackRouter: { ...geoRouter, updateRouteBetweenPoints: jest.fn() },
-    };
-
-    return ctx;
-}
+const createCtx = (points) => createEditorCtx({ points });
+const geoRouter = createEditorCtx().trackRouter;
 
 const entries = (ctx) => Object.values(ctx.routingCache);
 
 test('a segment is cached by its points and profile, a protected one is not cached', () => {
     const ctx = createCtx();
-    const [a, b] = [point(50), point(51)];
+    const [a, b] = [point(0), point(1)];
 
     TracksRoutingCache.addRoutingToCache(a, b, null, ctx);
     expect(entries(ctx)).toEqual([]);
@@ -45,8 +30,8 @@ test('a segment is cached by its points and profile, a protected one is not cach
     expect(entries(ctx)[0].startPoint.lat).toBe(50);
 
     entries(ctx)[0].geometry = ['routed'];
-    TracksRoutingCache.addRoutingToCache(point(50), b, line(), ctx);
-    TracksRoutingCache.addRoutingToCache(point(50, 'bike'), b, line(), ctx);
+    TracksRoutingCache.addRoutingToCache(point(0), b, line(), ctx);
+    TracksRoutingCache.addRoutingToCache(point(0, 'bike'), b, line(), ctx);
     expect(entries(ctx).map((e) => e.geometry)).toEqual([['routed'], null]);
 });
 
@@ -79,7 +64,7 @@ test('a failed request is not repeated', async () => {
     const ctx = createCtx();
     ctx.trackRouter.updateRouteBetweenPoints.mockRejectedValue(new Error('router down'));
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    TracksRoutingCache.addRoutingToCache(point(50), point(51), line(), ctx);
+    TracksRoutingCache.addRoutingToCache(point(0), point(1), line(), ctx);
 
     effectControlRouterRequests({ ctx, startedRouterJobs: 0, setStartedRouterJobs: jest.fn() });
     await flush();
@@ -90,7 +75,7 @@ test('a failed request is not repeated', async () => {
 });
 
 test('a routed segment goes into the track once, the segments that are gone leave the cache', () => {
-    const [a, b, gap, c, d] = [point(50), point(51), point(52, TracksManager.PROFILE_GAP), point(53), point(54)];
+    const [a, b, gap, c, d] = [point(0), point(1), point(2, TracksManager.PROFILE_GAP), point(3), point(4)];
     const ctx = createCtx([a, b, gap, c, d]);
     const saveChanges = jest.fn();
     EditablePolyline.mockImplementation(function () {
@@ -100,8 +85,8 @@ test('a routed segment goes into the track once, the segments that are gone leav
     TracksRoutingCache.addRoutingToCache(a, b, ab, ctx);
     TracksRoutingCache.addRoutingToCache(gap, c, gapC, ctx);
     TracksRoutingCache.addRoutingToCache(c, d, line(), ctx);
-    TracksRoutingCache.addRoutingToCache(point(60), point(61), old, ctx);
-    TracksRoutingCache.addRoutingToCache(point(62), point(63), null, ctx);
+    TracksRoutingCache.addRoutingToCache(point(10), point(11), old, ctx);
+    TracksRoutingCache.addRoutingToCache(point(12), point(13), null, ctx);
     const [abEntry, gapEntry, cdEntry, oldEntry] = entries(ctx);
     abEntry.geometry = gapEntry.geometry = oldEntry.geometry = ['routed'];
 
@@ -124,7 +109,7 @@ test('a routed segment goes into the track once, the segments that are gone leav
 
 test('undo restores the geometry of every segment from the cache and drops the unfinished ones', () => {
     jest.useFakeTimers();
-    const [a, b, gap, c, d] = [point(50), point(51), point(52, TracksManager.PROFILE_GAP), point(53), point(54)];
+    const [a, b, gap, c, d] = [point(0), point(1), point(2, TracksManager.PROFILE_GAP), point(3), point(4)];
     const ctx = createCtx([a, b, gap, c, d]);
     const pending = line();
     TracksRoutingCache.addRoutingToCache(a, b, line(), ctx);

--- a/tests/unit/src/tests/search/03-matched-objects.test.js
+++ b/tests/unit/src/tests/search/03-matched-objects.test.js
@@ -1,0 +1,96 @@
+import {
+    createSearchMatchedObjectActions,
+    getMatchedAmenityProperties,
+    hasValidMatchedObjectCoords,
+    MATCHED_OBJECT_TYPE_AMENITY,
+    MATCHED_OBJECT_TYPE_CITY,
+} from '@map/manager/SpatialSearchMatchedObjects';
+import { CATEGORY_TYPE, MATCHED_OBJECTS, POI_ID, POI_NAME } from '@map/infoblock/components/wpt/WptTagsProvider';
+
+const POI_TYPE = 'POI_TYPE';
+const amenity = (name, extra = {}) => ({ type: MATCHED_OBJECT_TYPE_AMENITY, name, lat: 50, lon: 30, ...extra });
+
+function actions(item) {
+    const ctx = {
+        setZoomToCoords: jest.fn(),
+        setCurrentObjectType: jest.fn(),
+        setSelectedPoiObj: jest.fn(),
+        setSelectedWpt: jest.fn(),
+        setMoveToMapObj: jest.fn(),
+    };
+    const deps = {
+        item,
+        t: (key) => key,
+        ctx,
+        navigate: jest.fn(),
+        recentSaver: jest.fn(),
+        setShowMatched: jest.fn(),
+        formatSearchResultProperties: (props) => ({ name: props.name }),
+        navigateToPoi: jest.fn(),
+        objectSearchType: 'search',
+        poiObjectsKey: 'poi',
+        poiTypeCategory: POI_TYPE,
+    };
+
+    return { ...createSearchMatchedObjectActions(deps), ...deps };
+}
+
+const event = () => ({ stopPropagation: jest.fn(), preventDefault: jest.fn() });
+
+test('the other places matched by a result are listed by name, the result itself is not', () => {
+    const cafe = amenity('Cafe', { [POI_ID]: 7 });
+    const res = actions({
+        properties: {
+            [CATEGORY_TYPE]: 'POI',
+            [MATCHED_OBJECTS]: [amenity('The result'), cafe, { type: MATCHED_OBJECT_TYPE_CITY, name: 'Kyiv' }],
+        },
+    });
+
+    expect(res.matchedNameObjects.map((m) => m.name)).toEqual(['Cafe']);
+    expect(res.matchedDialogObjects.map((m) => m.key)).toEqual(['Amenity-50-30-0', 7, 'City-undefined-undefined-2']);
+
+    res.matchedNameObjects[0].onClick(event());
+    expect(res.ctx.setSelectedWpt).toHaveBeenCalledWith({
+        poi: { key: 7, options: getMatchedAmenityProperties(cafe), latlng: { lat: 50, lng: 30 } },
+        id: 7,
+    });
+    expect(res.navigateToPoi).toHaveBeenCalledTimes(1);
+
+    // a place without coordinates cannot be opened
+    res.matchedDialogObjects[2].onClick();
+    expect(res.ctx.setZoomToCoords).not.toHaveBeenCalled();
+});
+
+test('a category result points to the first place it was matched in', () => {
+    const res = actions({
+        properties: {
+            [CATEGORY_TYPE]: POI_TYPE,
+            [MATCHED_OBJECTS]: [
+                { type: 'Unknown' },
+                { type: MATCHED_OBJECT_TYPE_CITY, name: 'Kyiv', lat: 50, lon: 30 },
+            ],
+        },
+    });
+
+    expect(res.matchedNameObjects.map((m) => m.name)).toEqual(['Kyiv']);
+    res.moveToMatchedPoiTypeLocation();
+    expect(res.ctx.setZoomToCoords).toHaveBeenCalledWith({ lat: 50, lon: 30, bbox: undefined });
+    expect(res.setShowMatched).toHaveBeenCalledWith(false);
+
+    expect(actions({ properties: {} }).matchedNameObjects).toEqual([]);
+});
+
+test('a matched amenity is described like a poi', () => {
+    expect(getMatchedAmenityProperties({ name: 'Cafe' })).toEqual({
+        name: 'Cafe',
+        [CATEGORY_TYPE]: 'POI',
+        [POI_NAME]: 'Cafe',
+    });
+    expect(getMatchedAmenityProperties({ [POI_NAME]: 'Cafe', [CATEGORY_TYPE]: 'WIKI' })).toMatchObject({
+        name: 'Cafe',
+        [CATEGORY_TYPE]: 'WIKI',
+    });
+    expect(hasValidMatchedObjectCoords({ lat: 0, lon: 0 })).toBe(false);
+    expect(hasValidMatchedObjectCoords({ lat: '50', lon: 30 })).toBe(false);
+    expect(hasValidMatchedObjectCoords({ lat: 50, lon: 30 })).toBe(true);
+});

--- a/tests/unit/src/tests/settings/00-cloud-changes.test.js
+++ b/tests/unit/src/tests/settings/00-cloud-changes.test.js
@@ -1,0 +1,115 @@
+import {
+    deleteFile,
+    deleteFileAllVersions,
+    deleteFileVersion,
+    emptyTrash,
+    formatString,
+    isFileRestrictedForDownload,
+    restoreFile,
+} from '@map/manager/SettingsManager';
+import { apiGet, apiPost } from '@map/util/HttpApi';
+import { findRequest } from '../../util/requests';
+
+const version = (name, updatetimems) => ({ id: `${name}-${updatetimems}`, name, type: 'GPX', updatetimems });
+const month = (date) => ({ type: 'month', date, id: `month-${date}` });
+const row = (file, isLast = false) => ({ type: 'file', file, id: file.id, isLast });
+
+// the changes list as CloudSettings builds it: a month header, then its versions, newest first
+const SEP = version('Sep.gpx', 3000);
+const AUG_NEW = version('Aug.gpx', 2000);
+const AUG_OLD = version('Aug.gpx', 1000);
+const changes = () => [month('Sep'), row(SEP, true), month('Aug'), row(AUG_NEW), row(AUG_OLD, true)];
+
+function list() {
+    const state = { changes: changes() };
+    state.setChanges = jest.fn((next) => (state.changes = next));
+
+    return state;
+}
+
+const ids = (state) => state.changes.map((c) => c.id);
+
+test('a deleted version leaves the list together with the month it was alone in', async () => {
+    apiPost.mockResolvedValue({ status: 200 });
+    const state = list();
+
+    await deleteFileVersion({ file: SEP, ...state });
+
+    expect(findRequest(apiPost, '/mapapi/delete-file-version').options.params).toEqual({
+        name: 'Sep.gpx',
+        type: 'GPX',
+        updatetime: 3000,
+    });
+    expect(ids(state)).toEqual(['month-Aug', AUG_NEW.id, AUG_OLD.id]);
+});
+
+test('all versions of a file go at once, a single file is deleted by its id', async () => {
+    apiGet.mockResolvedValue({ status: 200 });
+    apiPost.mockResolvedValue({ status: 200 });
+    const state = list();
+
+    await deleteFileAllVersions({ file: AUG_NEW, ...state, isTrash: true });
+
+    expect(findRequest(apiGet, '/mapapi/delete-file-all-versions').options.params).toEqual({
+        name: 'Aug.gpx',
+        type: 'GPX',
+        updatetime: 2000,
+        isTrash: true,
+    });
+    expect(ids(state)).toEqual(['month-Sep', SEP.id]);
+
+    await deleteFile({ file: SEP, ...state });
+
+    expect(findRequest(apiPost, '/mapapi/delete-file').options.params).toEqual({ name: 'Sep.gpx', type: 'GPX' });
+    expect(ids(state)).toEqual(['month-Sep']);
+});
+
+test('a restored version appears on top of the list, a file restored from the trash leaves it', async () => {
+    const restored = version('Aug.gpx', 4000);
+    apiGet.mockResolvedValue({ status: 200, data: restored });
+    const state = list();
+
+    await restoreFile({ file: AUG_OLD, ctx: {}, ...state });
+
+    expect(findRequest(apiGet, '/mapapi/restore-file').options.params).toEqual({
+        name: 'Aug.gpx',
+        type: 'GPX',
+        updatetime: 1000,
+    });
+    expect(ids(state)).toEqual(['month-Sep', restored.id, SEP.id, 'month-Aug', AUG_NEW.id, AUG_OLD.id]);
+    expect(state.changes[1]).toEqual({ file: restored, type: 'file', isLast: false, id: restored.id });
+
+    const trash = list();
+    await restoreFile({ file: SEP, ctx: {}, ...trash, fromTrash: true });
+    expect(ids(trash)).toEqual(['month-Aug', AUG_NEW.id, AUG_OLD.id]);
+
+    apiGet.mockResolvedValue({ status: 400, data: 'not found' });
+    const ctx = { setRoutingErrorMsg: jest.fn() };
+    await restoreFile({ file: SEP, ctx, ...list() });
+    expect(ctx.setRoutingErrorMsg).toHaveBeenCalledWith('not found');
+});
+
+test('emptying the trash sends every file of the list', async () => {
+    apiPost.mockResolvedValue({ status: 200 });
+    const state = list();
+
+    await emptyTrash({ ctx: {}, ...state });
+
+    const { body } = findRequest(apiPost, '/mapapi/empty-trash');
+    expect(body).toEqual([
+        { name: 'Sep.gpx', type: 'GPX', updatetime: 3000 },
+        { name: 'Aug.gpx', type: 'GPX', updatetime: 2000 },
+        { name: 'Aug.gpx', type: 'GPX', updatetime: 1000 },
+    ]);
+    expect(state.changes).toEqual([]);
+});
+
+test('a translation with android placeholders, and the files the server does not give back', () => {
+    expect(formatString('Delete \\"%1$s\\" from \\"%2$s\\"?', ['Track', 'Folder'])).toBe(
+        'Delete "Track" from "Folder"?'
+    );
+    // maps are served from the common server files, not from the user storage
+    expect(isFileRestrictedForDownload({ type: 'FILE', name: 'Ukraine.obf' })).toBe(true);
+    expect(isFileRestrictedForDownload({ type: 'file', name: 'tiles.sqlitedb' })).toBe(true);
+    expect(isFileRestrictedForDownload({ type: 'GPX', name: 'Track.gpx' })).toBe(false);
+});

--- a/tests/unit/src/tests/settings/00-cloud-changes.test.js
+++ b/tests/unit/src/tests/settings/00-cloud-changes.test.js
@@ -41,6 +41,11 @@ test('a deleted version leaves the list together with the month it was alone in'
         updatetime: 3000,
     });
     expect(ids(state)).toEqual(['month-Aug', AUG_NEW.id, AUG_OLD.id]);
+
+    await deleteFileVersion({ file: AUG_OLD, ...state });
+
+    // the row that became the last of its month loses the divider below it
+    expect(state.changes).toEqual([month('Aug'), row(AUG_NEW, true)]);
 });
 
 test('all versions of a file go at once, a single file is deleted by its id', async () => {
@@ -61,7 +66,7 @@ test('all versions of a file go at once, a single file is deleted by its id', as
     await deleteFile({ file: SEP, ...state });
 
     expect(findRequest(apiPost, '/mapapi/delete-file').options.params).toEqual({ name: 'Sep.gpx', type: 'GPX' });
-    expect(ids(state)).toEqual(['month-Sep']);
+    expect(state.changes).toEqual([]);
 });
 
 test('a restored version appears on top of the list, a file restored from the trash leaves it', async () => {

--- a/tests/unit/src/tests/tracks/14-track-distance.test.js
+++ b/tests/unit/src/tests/tracks/14-track-distance.test.js
@@ -1,0 +1,111 @@
+import TracksManager, {
+    addDistanceToPoints,
+    eligibleToApplySrtm,
+    getTrackPoints,
+    hasSegments,
+    hasSegmentTurns,
+    isEmptyTrack,
+    NAN_MARKER,
+    validateRoutePoints,
+} from '@map/manager/track/TracksManager';
+
+const GAP = TracksManager.PROFILE_GAP;
+const STEP = 1112; // meters between two points 0.01 degrees apart along a meridian
+
+const point = (i, extra = {}) => ({ lat: 50 + i / 100, lng: 30, ...extra });
+const near = (meters) => expect.closeTo(meters, -1);
+
+describe('addDistanceToPoints', () => {
+    test('a plain track counts the distance from the previous point, a gap starts a new segment', () => {
+        const points = [point(0), point(1), point(2, { profile: GAP }), point(3), point(4)];
+
+        addDistanceToPoints(points);
+
+        expect(points.map((p) => p.dist)).toEqual([0, near(STEP), near(STEP), 0, near(STEP)]);
+        expect(points.map((p) => p.distanceSegment)).toEqual([0, near(STEP), near(2 * STEP), 0, near(STEP)]);
+        expect(points.map((p) => p.distanceTotal)).toEqual([
+            0,
+            near(STEP),
+            near(2 * STEP),
+            near(2 * STEP),
+            near(3 * STEP),
+        ]);
+    });
+
+    test('a routed point is as long as its geometry, the distances of the router are kept', () => {
+        const geometry = (i, last = {}) => [point(i - 1), point(i, { distance: 1000 }), { ...point(i), ...last }];
+        const points = [
+            point(0, { geometry: [] }),
+            point(1, { geometry: geometry(1, { profile: GAP }) }),
+            point(2, { geometry: geometry(2) }),
+        ];
+
+        addDistanceToPoints(points);
+
+        // the first point of a geometry is the previous point itself, the third is a copy of the second
+        expect(points[1].geometry.map((g) => g.distance)).toEqual([0, 1000, 0]);
+        expect(points.map((p) => p.dist)).toEqual([0, 1000, 1000]);
+        expect(points.map((p) => p.distanceSegment)).toEqual([0, 1000, 1000]);
+        expect(points.map((p) => p.distanceTotal)).toEqual([0, 1000, 2000]);
+    });
+});
+
+describe('getTrackPoints', () => {
+    test('the tracks of a file are joined with the total distance running on', () => {
+        const first = [point(0), point(1)];
+        const second = [point(5), point(6)];
+        addDistanceToPoints(first);
+        addDistanceToPoints(second);
+        const file = { tracks: [{ points: first }, { points: second }] };
+
+        const totals = getTrackPoints(file).map((p) => p.distanceTotal);
+
+        expect(totals).toEqual([0, near(STEP), near(STEP), near(2 * STEP)]);
+        // asking again gives the same distances, the points are not shifted a second time
+        expect(getTrackPoints(file).map((p) => p.distanceTotal)).toEqual(totals);
+    });
+
+    test('the geometry of a routed track is unfolded into points', () => {
+        const file = { points: [point(0), point(1, { geometry: [point(0), point(1)] })] };
+
+        expect(getTrackPoints(file)).toHaveLength(3);
+    });
+});
+
+test('the points of the editor are taken into the track only when every segment is routed', () => {
+    const routed = [point(0, { geometry: [] }), point(1, { geometry: [point(0), point(1)] })];
+
+    expect(validateRoutePoints(routed)).toBe(true);
+    expect(validateRoutePoints([point(0), point(1)])).toBe(true);
+    expect(validateRoutePoints([...routed, point(2, { profile: GAP })])).toBe(true);
+    expect(validateRoutePoints([...routed, point(2)])).toBe(false);
+    expect(validateRoutePoints([point(0, { geometry: [point(0)] }), routed[1]])).toBe(false);
+    expect(validateRoutePoints([])).toBe(false);
+});
+
+describe('eligibleToApplySrtm', () => {
+    const track = (eles, analysis = {}) => ({ points: eles.map((ele, i) => point(i, { ele })), analysis });
+
+    test('srtm is offered when the elevation is missing or all zero, once', () => {
+        expect(eligibleToApplySrtm({ track: track([100, 101, 102, 103, 104]) })).toBe(false);
+        expect(eligibleToApplySrtm({ track: track([100, NAN_MARKER, 102, 103, 104]) })).toBe(true);
+        expect(eligibleToApplySrtm({ track: track([0, 0, 0, 0, 0]) })).toBe(true);
+        expect(eligibleToApplySrtm({ track: track([0, 0, 0, 0, 0], { isSrtmApplied: true }) })).toBe(false);
+        // too short to bother
+        expect(eligibleToApplySrtm({ track: track([0, 0, 0, 0]) })).toBe(false);
+        expect(eligibleToApplySrtm({ track: track([0, 0, 0, 0], null) })).toBe(false);
+    });
+});
+
+test('what counts as an empty track, a track with segments and a track with turns', () => {
+    const turn = { geometry: [{ segment: { ext: { turnType: 'left' } } }] };
+
+    expect(isEmptyTrack({})).toBe(true);
+    expect(isEmptyTrack({ wpts: [{}] })).toBe(false);
+    expect(isEmptyTrack({ wpts: [{}] }, false)).toBe(true);
+    expect(isEmptyTrack({ tracks: [{ points: [{}] }] }, true, false)).toBe(true);
+    expect(hasSegments({ tracks: [{ points: [{}, {}] }] })).toBe(true);
+    expect(hasSegments({ points: [{}] })).toBe(false);
+    expect(hasSegmentTurns({ track: { points: [{}, turn] } })).toBe(true);
+    expect(hasSegmentTurns({ track: { tracks: [{ points: [{}] }] } })).toBe(false);
+});

--- a/tests/unit/src/tests/tracks/15-track-points.test.js
+++ b/tests/unit/src/tests/tracks/15-track-points.test.js
@@ -1,0 +1,92 @@
+import PointManager from '@map/manager/PointManager';
+import TrackLayerProvider from '@map/map/util/TrackLayerProvider';
+import { createEditorCtx, createEditorPoint, createRoutedPoints } from '../../util/fixtures/tracks';
+
+TrackLayerProvider.createTempPolyline = () => ({ temp: true });
+
+const plain = (n) => Array.from({ length: n }, (_, i) => createEditorPoint(i));
+const createCtx = (points) => createEditorCtx({ points });
+
+const lats = (points) => points.map((p) => p.lat);
+
+describe('deletePoint', () => {
+    test('the neighbours of a deleted point are joined, a routed segment is routed again', async () => {
+        const first = createCtx(createRoutedPoints(3));
+        await PointManager.deletePoint(0, first);
+        expect(lats(first.selectedGpxFile.points)).toEqual([50.01, 50.02]);
+        expect(first.selectedGpxFile.points[0].geometry).toEqual([]);
+
+        const last = createCtx(createRoutedPoints(3));
+        await PointManager.deletePoint(2, last);
+        expect(lats(last.selectedGpxFile.points)).toEqual([50, 50.01]);
+
+        const middle = createCtx(createRoutedPoints(3));
+        await PointManager.deletePoint(1, middle);
+        expect(lats(middle.selectedGpxFile.points)).toEqual([50, 50.02]);
+        // the segment from the first point to the third is routed anew
+        expect(middle.selectedGpxFile.points[1].geometry).toEqual([]);
+        expect(Object.values(middle.routingCache)).toMatchObject([
+            { startPoint: { lat: 50 }, endPoint: { lat: 50.02 }, geometry: null },
+        ]);
+        expect(middle.selectedGpxFile.layers.addLayer).toHaveBeenCalledTimes(1);
+        expect(middle.selectedGpxFile.updateLayers).toBe(true);
+
+        const line = createCtx(plain(3));
+        await PointManager.deletePoint(1, line);
+        expect(lats(line.selectedGpxFile.points)).toEqual([50, 50.02]);
+        expect(line.routingCache).toEqual({});
+    });
+
+    test('a track left without points is emptied', async () => {
+        const ctx = createCtx(plain(2));
+
+        await PointManager.deletePoint(1, ctx);
+        expect(ctx.setUpdateInfoBlock).toHaveBeenCalledWith(true);
+
+        await PointManager.deletePoint(0, ctx);
+        expect(ctx.selectedGpxFile.points).toEqual([]);
+        expect(ctx.selectedGpxFile.name).toBe('Local');
+        expect(ctx.selectedGpxFile.tracks).toBeDefined();
+    });
+});
+
+describe('reorder', () => {
+    test('a moved point is routed from its new neighbours', async () => {
+        const ctx = createCtx(createRoutedPoints(4));
+
+        await PointManager.reorder(3, 1, ctx.selectedGpxFile, ctx);
+
+        const points = ctx.selectedGpxFile.points;
+        expect(lats(points)).toEqual([50, 50.03, 50.01, 50.02]);
+        expect(lats(points[1].geometry)).toEqual([50, 50.03]);
+        expect(lats(points[2].geometry)).toEqual([50.03, 50.01]);
+        expect(lats(points[3].geometry)).toEqual([50.01, 50.02]);
+    });
+
+    test('a point moved to the start has no segment leading to it', async () => {
+        const ctx = createCtx(createRoutedPoints(3));
+
+        await PointManager.reorder(2, 0, ctx.selectedGpxFile, ctx);
+
+        const points = ctx.selectedGpxFile.points;
+        expect(lats(points)).toEqual([50.02, 50, 50.01]);
+        expect(points[0].geometry).toEqual([]);
+        expect(lats(points[1].geometry)).toEqual([50.02, 50]);
+    });
+});
+
+test('deleteWpt removes the waypoint and asks for a redraw', () => {
+    const ctx = createCtx([]);
+    ctx.selectedGpxFile.wpts = [{ name: 'a' }, { name: 'b' }];
+    ctx.selectedGpxFile.wptChangedFlag = 0;
+
+    PointManager.deleteWpt(0, ctx, true);
+
+    expect(ctx.selectedGpxFile).toMatchObject({
+        wpts: [{ name: 'b' }],
+        updateLayers: true,
+        wptChangedFlag: 1,
+        save: true,
+    });
+    expect(ctx.setTrackState).toHaveBeenCalledWith({ update: true });
+});

--- a/tests/unit/src/tests/util/07-url-and-storage.test.js
+++ b/tests/unit/src/tests/util/07-url-and-storage.test.js
@@ -1,0 +1,55 @@
+import { createUrlParams, decodeString, encodeString, isToday, isYesterday, truncateText } from '@map/util/Utils';
+import { getFileStorage, updateFileStorage, GPX } from '@map/manager/GlobalManager';
+import { SHARE_TYPE } from '@map/menu/share/shareConstants';
+
+test('a file name survives the trip through the url', () => {
+    const name = 'Папка/Трек №1 (2026).gpx';
+
+    expect(decodeString(encodeString(name))).toBe(name);
+    expect(encodeString(name)).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(encodeString(null)).toBeNull();
+    expect(decodeString('not base64!')).toBeNull();
+});
+
+test('the query string keeps commas, colons and semicolons readable', () => {
+    expect(createUrlParams({ pin: '50.45,30.52', time: '12:00', list: 'a;b' })).toBe(
+        '?pin=50.45,30.52&time=12:00&list=a;b'
+    );
+    expect(createUrlParams({ q: 'a b&c' })).toBe('?q=a+b%26c');
+    expect(createUrlParams({})).toBe('');
+});
+
+test('today and yesterday are calendar days, also across a month', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 9, 1, 0, 30)); // 1 October, half past midnight
+
+    expect(isToday(new Date(2026, 9, 1, 23, 59))).toBe(true);
+    expect(isToday(new Date(2026, 8, 30, 23, 59))).toBe(false);
+    expect(isYesterday(new Date(2026, 8, 30, 0, 0))).toBe(true);
+    expect(isYesterday(new Date(2025, 8, 30))).toBe(false);
+
+    jest.useRealTimers();
+    expect(truncateText('a long name', 6)).toBe('a long...');
+    expect(truncateText('short', 6)).toBe('short');
+});
+
+test('shared tracks and own tracks live in different storages', () => {
+    const ctx = {
+        gpxFiles: { 'Own.gpx': { name: 'Own.gpx' } },
+        shareWithMeFiles: { tracks: { 'Shared.gpx': { name: 'Shared.gpx' } } },
+        setGpxFiles: jest.fn((update) => (ctx.gpxFiles = update(ctx.gpxFiles))),
+        setShareWithMeFiles: jest.fn((update) => (ctx.shareWithMeFiles = update(ctx.shareWithMeFiles))),
+    };
+
+    expect(getFileStorage({ ctx, smartf: null, type: GPX })).toBe(ctx.gpxFiles);
+    expect(getFileStorage({ ctx, smartf: { type: SHARE_TYPE }, type: GPX })).toBe(ctx.shareWithMeFiles.tracks);
+    expect(getFileStorage({ ctx, smartf: null, type: 'FAVOURITES' })).toBeNull();
+
+    updateFileStorage({ ctx, smartf: null, type: GPX, file: { name: 'New.gpx' } });
+    updateFileStorage({ ctx, smartf: { type: SHARE_TYPE }, type: GPX, file: { name: 'Shared.gpx', url: 'x' } });
+
+    expect(Object.keys(ctx.gpxFiles)).toEqual(['Own.gpx', 'New.gpx']);
+    expect(ctx.shareWithMeFiles.tracks['Shared.gpx'].url).toBe('x');
+    expect(Object.keys(ctx.gpxFiles)).not.toContain('Shared.gpx');
+});

--- a/tests/unit/src/util/fixtures/tracks.js
+++ b/tests/unit/src/util/fixtures/tracks.js
@@ -60,3 +60,40 @@ export function createCtx({ track, cloud = true, uniqueFiles = [] } = {}) {
 export function createInfoFile({ name = CLOUD_TRACK_NAME, updatetimems = 1700000000000, data = {} } = {}) {
     return { name: name + '.info', updatetimems, details: { data } };
 }
+
+/** Point of the track editor `i` hundredths of a degree north of 50, optionally with the geometry leading to it. */
+export function createEditorPoint(i, { profile = 'car', geometry } = {}) {
+    return { lat: 50 + i / 100, lng: 30, profile, ...(geometry && { geometry }) };
+}
+
+/** Routed track of the editor: every point but the first carries the geometry of the segment leading to it. */
+export function createRoutedPoints(n) {
+    return Array.from({ length: n }, (_, i) =>
+        createEditorPoint(i, { geometry: i === 0 ? [] : [createEditorPoint(i - 1), createEditorPoint(i)] })
+    );
+}
+
+/**
+ * ctx of the track editor: a local track open on the map, the routing cache and a router that answers
+ * with a straight line. `geoRouter` is what the layers pass around separately from ctx.
+ */
+export function createEditorCtx({ points = [] } = {}) {
+    const track = { name: 'Local', points, layers: { addLayer: jest.fn(), getLayers: () => [] } };
+    const ctx = createCtx({ track, cloud: false });
+    ctx.createTrack = { enable: false };
+    ctx.trackState = {};
+    ctx.routingCache = {};
+    ctx.mutateRoutingCache = (update) => update(ctx.routingCache);
+    ctx.trackRouter = {
+        getGeoProfile: (point) => ({ profile: point.profile, cacheKey: `key-${point.profile}` }),
+        getColor: () => '#0000ff',
+        updateRouteBetweenPoints: jest.fn(async (ctx, start, end) => ({ points: [start, end] })),
+    };
+    ctx.setTrackState = jest.fn();
+    ctx.setProcessRouting = jest.fn();
+    ctx.setUpdateInfoBlock = jest.fn();
+    ctx.setLoadingContextMenu = jest.fn();
+    ctx.setUnverifiedGpxFile = jest.fn();
+
+    return ctx;
+}


### PR DESCRIPTION
## AI disclaimer

Written with Claude (Cowork, Claude Fable 5.1), driven by [@alisa911](https://github.com/alisa911). Summary of the requests it worked from, in order:

1. After a review of the previous PR found a test that pinned broken behaviour, asked to go through every unit test again and check whether each expectation is what the app should do, not what the code does. All 31 files were checked against the server (osmandapp/tools) and Android (osmandapp/android). One test was found to pin a real divergence - the web escapes both `/` and `:` in a favorite group file name while Android escapes only the first one it finds - and a few more doubtful cases; they went into KNOWN_ISSUES.md (not part of this PR), and the rule "expect what the app should do, not what it does" went into the add-test skill.

2. Cover the routing cache of the track editor. `effectControlRouterRequests` let a seventh request through when six were in flight (`>` instead of `>=` against `MAX_STARTED_ROUTER_JOBS`); fixed after asking. Six tests in `routing/01-routing-cache.test.js`: a segment is cached by its points and profile, a failed request is not repeated, a routed segment goes into the track once, undo restores the geometry from the cache, the debouncer keeps the last call.

3. Cover the distances of a track. `getTrackPoints` shifted `distanceTotal` of the second and following `<trk>` of a file in place, and it is called on every redraw of the graph, so the distance axis grew on each call. The author asked to re-check that the bug is real before fixing; the chain was verified end to end (`WebGpxParser.getTracks` returns one entry per `<trk>`, `addDistance` counts each from zero, `getAllPoints` returns references, `GpxGraphProvider` reads `distanceTotal`). Fixed by shifting copies; seven tests in `tracks/14-track-distance.test.js`. The first version of the test compared mutated points with themselves and passed - caught and rewritten to snapshot the numbers first.

4. Cover deleting and reordering the points of a track. A point dragged to the first place in the Points tab kept the geometry of its old segment, so `validateRoutePoints` rejected the track and the analysis and the save ignored the reorder; fixed in `insertPoint`. The author reminded about the add-test skill: the inline contexts of the new tests were moved into `fixtures/tracks.js` (`createEditorCtx`, `createEditorPoint`, `createRoutedPoints`). Five tests in `tracks/15-track-points.test.js`.

5. Cover the conversion of a navigation route into a track. No bugs; three tests in `navigation/00-route-to-track.test.js` (segments cut at the route points, a via point snapped to the line, alternatives left out, elevation borrowed at the ends of the line). Two doubts noted without a fix: a round trip whose finish is on the start collapses both into one map entry, and the point shared by two segments was counted twice in the average elevation - the latter was fixed on review, see 8.

6. Cover the cloud changes and trash. `deleteVersionsFromMenu` kept the header of a month whose files were all deleted as long as any later month still had a file; the author asked to re-check, the rendering in `CloudChanges` / `CloudTrash` was confirmed to draw headers as they come; fixed. Five tests in `settings/00-cloud-changes.test.js`.

7. Cover the url helpers, the file storages and the matched objects of the spatial search. No bugs; seven tests in `util/07-url-and-storage.test.js` and `search/03-matched-objects.test.js`. A matched amenity without coordinates would be listed as a link that does nothing - not pinned by a test, since the server builds matched objects from map objects with coordinates.

8. Four review comments applied: `deleteFile` now goes through `deleteVersionsFromMenu` like `restoreFile` (the test had pinned the leftover month header again); `isLast` of the row that became the last of its month is recomputed, so no divider is drawn before the next header; the point shared by two segments of a route counts once in `createAnalysisFromRoute` (the test expects 115 with the arithmetic written down); the skill names the repositories instead of local paths.

No commits were made by the agent; every commit was reviewed and made by the author. The 406 unit tests were run by the agent, the selenium suite by the author.

<img width="260" height="38" alt="Screenshot 2026-09-08 at 15 51 53" src="https://github.com/user-attachments/assets/9e342d28-fa61-4e96-93e2-31715a880b51" />
